### PR TITLE
#30 - 'es' single file rollup.config output entry and fjl package version update

### DIFF
--- a/packages/fjl/package.json
+++ b/packages/fjl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fjl",
-  "version": "1.13.0",
+  "version": "2.0.0-alpha",
   "description": "Functional Javascript Library.",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,6 +48,19 @@ const
     }, {
       ...configBase,
       output: {
+        format: 'es',
+        file: path.join(projectPath, 'dist/index.es.min.js'),
+        sourcemap: true
+      },
+      plugins: [
+        typescript({
+          tsconfig: path.join(projectPath, './tsconfig.prod.es.json'),
+        }),
+        terser()
+      ]
+    }, {
+      ...configBase,
+      output: {
         format: 'amd',
         dir: path.join(projectPath, 'dist/amd/'),
         preserveModules: true,


### PR DESCRIPTION
Added 'es' output, rollup.config, for minified single file modu…le format.  Changed fjl package version to 2.0.0-alpha.