### PR TITLE
issue-#87 - Updates `take*`, and `drop`/`dropWhile`, methods to accept an `Iterable<T>` instead of custom type

### DIFF
--- a/packages/fjl-inputfilter/tests/test-Input.ts
+++ b/packages/fjl-inputfilter/tests/test-Input.ts
@@ -1,7 +1,7 @@
 /**
  * Created by Ely on 3/26/2016.
  */
-import {curry, error, isArray, isBoolean, isEmpty, keys, peek, repeat, subsequences} from 'fjl';
+import {curry, error, isArray, isBoolean, isEmpty, keys, repeat, subsequences, take} from 'fjl';
 import {notEmptyValidator, regexValidator, stringLengthValidator} from 'fjl-validator';
 import {
   Input,
@@ -88,7 +88,7 @@ describe('#runValidators', function () {
       // [ValidationResult, ExpectedResultResult, MessagesLength]
       [runValidators(inputOptionObjs[0].validators, breakOnFailure, 'hello-world'), true, 0],
       [runValidators(inputOptionObjs[1].validators, breakOnFailure, ''), false, 2],
-      [runValidators(inputOptionObjs[1].validators, breakOnFailure, repeat(100, 'a').join('')), false, 1]
+      [runValidators(inputOptionObjs[1].validators, breakOnFailure, take(100, repeat('a')).join('')), false, 1]
     ]
       .concat(
         subsequences('hello')

--- a/packages/fjl-validator/src/ValidationUtils.ts
+++ b/packages/fjl-validator/src/ValidationUtils.ts
@@ -11,6 +11,7 @@ import {
   isFunction,
   isString,
   repeat,
+  take,
   Unary
 } from 'fjl';
 
@@ -41,7 +42,7 @@ export const
   /**
    * Default value obscurer.
    */
-  defaultValueObscurer = <T>(x: T): string => repeat((x + '').length, '*') as unknown as string,
+  defaultValueObscurer = <T>(x: T): string => take((x + '').length, repeat('*')).join(''),
 
   $getErrorMsgByKey = <T, Options extends ValidatorOptions<T>>(
     options: Options, key: keyof MessageTemplates<T> | MessageGetter<T>, value: T): string | undefined => {

--- a/packages/fjl/src/_platform/object/index.ts
+++ b/packages/fjl/src/_platform/object/index.ts
@@ -67,7 +67,9 @@ export const
   }, {}) as ObjectStatics,
 
   /**
-   * Functional version of `instanceof` operator.
+   * Functional `instanceof` combinator which first checks
+   * if passed in value's constructor is equal to the given one, and if result is `false`
+   * checks whether value is an instance of the given constructor.
    */
   instanceOf = (x: any, X: Constructable): boolean =>
     x.constructor === X || x instanceof X,
@@ -79,6 +81,8 @@ export const
 
   /**
    * Functional version of `Object.prototype.hasOwnProperty`.
+   * Note: Is defined as `Object.hasOwn` if available, otherwise uses
+   * `Object.prototype.hasOwnProperty` in declaration.
    */
   hasOwnProperty = Object.hasOwn ?? (<T extends object>(x: T, key: string | PropertyKey): boolean =>
     // @note `Object.hasOwn` cannot be used here until it is more broadly

--- a/packages/fjl/src/list/append.ts
+++ b/packages/fjl/src/list/append.ts
@@ -5,14 +5,14 @@ export const
   /**
    * Append two, or more, lists, i.e.,
    * ```
-   * expectEqual(append(take(13, alphabetString), drop(13, alphabetString)), alphabetString); // true
+   * expect(append(take(13, alphabetString), drop(13, alphabetString))).toEqual(alphabetString); // true
    *
    * // Another example
    * const result = append(
    *   alphabetStr.split(''),
    *   alphabetStr.split('')
    * ),
-   * expected = repeat(2, alphabetStr).split('');
+   * expected = take(2, repeat(alphabetStr));
    *
    * shallowEquals(result, expected) === true // `true`
    * ```

--- a/packages/fjl/src/list/drop.ts
+++ b/packages/fjl/src/list/drop.ts
@@ -1,16 +1,14 @@
-import {Slice} from "../types";
 import {instanceOfSome} from "../object";
 
 export const
 
   /**
-   * Drops `n` items from start of list.
-   *
-   * **Note:** Returns `string` type for strings, and `Array` type otherwise.
+   * Drops `n` items from start of iterable and returns a corresponding list (
+   *  string (if iterable is a string), or array).
    */
-  drop = <T = any>(n: number, xs: Slice<T> | Iterable<T>): typeof xs | T[] => {
+  drop = <T = any>(n: number, xs: Iterable<T>): typeof xs | T[] => {
     if (instanceOfSome(xs, String, Array))
-      return (xs as (string | T[])).slice(n);
+      return (xs as (string | T[])).slice(n) as typeof xs;
 
     const out = [] as T[];
     for (const x of xs) {
@@ -26,6 +24,6 @@ export const
    * @curried
    */
   $drop = <T = any>(n: number) =>
-    (xs: Slice<T> | Iterable<T>): typeof xs | T[] => drop(n, xs)
+    (xs: Iterable<T>): typeof xs | T[] => drop(n, xs)
 
 ;

--- a/packages/fjl/src/list/drop.ts
+++ b/packages/fjl/src/list/drop.ts
@@ -1,11 +1,31 @@
-import {$sliceFrom, sliceFrom} from "./utils/sliceFrom";
+import {Slice} from "../types";
+import {instanceOfSome} from "../object";
 
 export const
 
-  $drop = $sliceFrom,
+  /**
+   * Drops `n` items from start of list.
+   *
+   * **Note:** Returns `string` type for strings, and `Array` type otherwise.
+   */
+  drop = <T = any>(n: number, xs: Slice<T> | Iterable<T>): typeof xs | T[] => {
+    if (instanceOfSome(xs, String, Array))
+      return (xs as (string | T[])).slice(n);
+
+    const out = [] as T[];
+    for (const x of xs) {
+      if (n-- > 0) continue;
+      out.push(x as T);
+    }
+    return out;
+  },
 
   /**
-   * Drops `n` items from start of list to `count` (exclusive).
+   * Curried version of `drop`.
+   *
+   * @curried
    */
-  drop = sliceFrom;
+  $drop = <T = any>(n: number) =>
+    (xs: Slice<T> | Iterable<T>): typeof xs | T[] => drop(n, xs)
 
+;

--- a/packages/fjl/src/list/drop.ts
+++ b/packages/fjl/src/list/drop.ts
@@ -1,15 +1,9 @@
-import {instanceOfSome} from "../object";
-
 export const
 
   /**
-   * Drops `n` items from start of iterable and returns a corresponding list (
-   *  string (if iterable is a string), or array).
+   * Drops `n` items from start of iterable and returns an array containing the non-dropped items.
    */
-  drop = <T = any>(n: number, xs: Iterable<T>): typeof xs | T[] => {
-    if (instanceOfSome(xs, String, Array))
-      return (xs as (string | T[])).slice(n) as typeof xs;
-
+  drop = <T = any>(n: number, xs: Iterable<T>): T[] => {
     const out = [] as T[];
     for (const x of xs) {
       if (n-- > 0) continue;
@@ -24,6 +18,6 @@ export const
    * @curried
    */
   $drop = <T = any>(n: number) =>
-    (xs: Iterable<T>): typeof xs | T[] => drop(n, xs)
+    (xs: Iterable<T>): T[] => drop(n, xs)
 
 ;

--- a/packages/fjl/src/list/dropWhile.ts
+++ b/packages/fjl/src/list/dropWhile.ts
@@ -1,23 +1,34 @@
-import {findIndexWhere} from "./utils";
 import {TernaryPred} from "../types";
+import {instanceOf} from "../_platform";
 
 export const
 
   /**
-   * Returns a list without elements that match predicate.
+   * Drops elements, from start of iterable, fulfilling predicate, and returns
+   * a list (string if iterable is a string) of the remaining items.
    */
-  dropWhile = <T>(p: TernaryPred, xs: string | T[]): typeof xs => {
-    const limit = xs.length,
-      splitPoint: number = findIndexWhere(
-        (x, i, xs) => !p(x, i, xs),
-        xs
-      );
-    return splitPoint === -1 ? xs.slice(limit) :
-      xs.slice(splitPoint, limit);
+  dropWhile = <T>(p: TernaryPred, xs: Iterable<T>): typeof xs | T[] => {
+    let index = -1,
+      thresholdReached = false;
+
+    const out = [];
+
+    for (const x of xs) {
+      index++;
+      const dropCurrent = p(x, index, xs);
+      if (!thresholdReached && dropCurrent) continue;
+      else if (!thresholdReached && !dropCurrent) thresholdReached = true;
+      out.push(x);
+    }
+
+    return instanceOf(xs, String) ? (out.join("") as Iterable<T>) : out;
   },
 
+  /**
+   * Curried version of `dropWhile`.
+   */
   $dropWhile = <T>(p: TernaryPred) =>
-    (xs: string | T[]): typeof xs =>
+    (xs: Iterable<T>): typeof xs | T[] =>
       dropWhile(p, xs)
 
 ;

--- a/packages/fjl/src/list/dropWhile.ts
+++ b/packages/fjl/src/list/dropWhile.ts
@@ -1,5 +1,4 @@
 import {TernaryPred} from "../types";
-import {instanceOf} from "../_platform";
 
 export const
 
@@ -7,7 +6,7 @@ export const
    * Drops elements, from start of iterable, fulfilling predicate, and returns
    * a list (string if iterable is a string) of the remaining items.
    */
-  dropWhile = <T>(p: TernaryPred, xs: Iterable<T>): typeof xs | T[] => {
+  dropWhile = <T>(p: TernaryPred, xs: Iterable<T>): T[] => {
     let index = -1,
       thresholdReached = false;
 
@@ -21,14 +20,13 @@ export const
       out.push(x);
     }
 
-    return instanceOf(xs, String) ? (out.join("") as Iterable<T>) : out;
+    return out;
   },
 
   /**
    * Curried version of `dropWhile`.
    */
   $dropWhile = <T>(p: TernaryPred) =>
-    (xs: Iterable<T>): typeof xs | T[] =>
-      dropWhile(p, xs)
+    (xs: Iterable<T>): T[] => dropWhile(p, xs)
 
 ;

--- a/packages/fjl/src/list/dropWhileEnd.ts
+++ b/packages/fjl/src/list/dropWhileEnd.ts
@@ -4,6 +4,9 @@ import {negateF3} from "../function";
 
 export const
 
+  /**
+   * Drops items off end of list while predicate holds.
+   */
   dropWhileEnd = <T>(
     pred: TernaryPred,
     xs: string | T[]
@@ -16,6 +19,9 @@ export const
     return xs.slice(0, splitPoint + 1);
   },
 
+  /**
+   * Curried version of `dropWhileEnd`.
+   */
   $dropWhileEnd = <T>(p: TernaryPred) =>
     (xs: string | T[]): typeof xs =>
       dropWhileEnd(p, xs)

--- a/packages/fjl/src/list/take.ts
+++ b/packages/fjl/src/list/take.ts
@@ -1,18 +1,11 @@
-import {Slice} from "../types";
-import {instanceOfSome} from "../object";
-
 /**
  * Returns the first `n` items from an iterable (e.g., string, array, generator, etc.).
- * **Note:** string type is returned for strings, array type otherwise.
  */
-export const take = <T=any>(n: number, xs: Slice<T> | Iterable<T>): typeof xs | T[] => {
-    if (instanceOfSome(xs, String, Array))
-      return (xs as (string | T[])).slice(0, n);
-
+export const take = <T>(n: number, xs: Iterable<any>): T[] => {
     const out = [] as T[];
     for (const x of xs) {
       if (n-- === 0) break;
-      out.push(x as T);
+      out.push(x);
     }
     return out;
   },
@@ -20,5 +13,4 @@ export const take = <T=any>(n: number, xs: Slice<T> | Iterable<T>): typeof xs | 
   /**
    * Curried version of `take`.
    */
-  $take = <T>(n: number) =>
-    (xs: Slice<T> | Iterable<T>): typeof xs | T[] => take(n, xs);
+  $take = <T>(n: number) => (xs: Iterable<T>): T[] => take(n, xs);

--- a/packages/fjl/src/list/takeWhile.ts
+++ b/packages/fjl/src/list/takeWhile.ts
@@ -1,13 +1,11 @@
 import {TernaryPred} from "../types";
-import {instanceOf} from "../_platform";
 
 export const
 
   /**
    * Returns items upto point where predicate doesn't hold.
-   * For string type returns a string.
    */
-  takeWhile = <T>(pred: TernaryPred, xs: Iterable<T>): typeof xs | T[] => {
+  takeWhile = <T>(pred: TernaryPred, xs: Iterable<T>): T[] => {
     let i = 0;
     const out = [];
     for (const x of xs) {
@@ -15,9 +13,10 @@ export const
       out.push(x);
       i += 1;
     }
-    return instanceOf(xs, String) ? out.join('') as typeof xs : out;
+    return out;
   },
 
   $takeWhile = <T>(pred: TernaryPred) =>
-    (xs: Iterable<T>): typeof xs | T[] =>
-      takeWhile(pred, xs);
+    (xs: Iterable<T>): T[] => takeWhile(pred, xs)
+
+;

--- a/packages/fjl/src/list/utils/findIndexWhere.ts
+++ b/packages/fjl/src/list/utils/findIndexWhere.ts
@@ -7,6 +7,8 @@ export const
 
   /**
    * Finds index in "number indexable" (string|array|etc.) that matches given predicate or -1.
+   *
+   * @todo Should support any indexable/Iterable/IterableIterator types
    */
   findIndexWhere = (
     pred: TernaryPred,

--- a/packages/fjl/src/types/data.ts
+++ b/packages/fjl/src/types/data.ts
@@ -12,7 +12,7 @@ export interface Nameable {
 /**
  * Represents strings, arrays, and/or, any structures that contain a `length`, and number indices.
  *
- * @todo Consider deprecating this for [native] `Iterable<T>` type.
+ * @todo Consider using `Iterable<T>` type, instead of this type, where it makes sense.
  */
 export type  NumberIndexable<T = unknown> = ({
   length: number;
@@ -23,10 +23,11 @@ export type  NumberIndexable<T = unknown> = ({
    */
   {
     readonly length: number;
-    readonly [index: number]: any; // for `String`/`string`, type here
-    // should actually be `string`, this is too strict, for
-    // a Sum type, however, so `any` is used instead (works fine)
-    // interchangeably targeting `string`, and/or `Array` types, from overall type.
+    readonly [index: number]: any; // Even though string variant type here
+    // should actually be `string`, this is too strict for
+    // a Sum type so `any` is used instead - this allows
+    // `string`, and/or `Array` types, to be used where `NumberIndexable` type is required,
+    // interchangeably.
   });
 
 /**

--- a/packages/fjl/tests/list/test-drop.ts
+++ b/packages/fjl/tests/list/test-drop.ts
@@ -1,34 +1,30 @@
-import {Slice} from "../../src/types/data";
-import {expectEqual, expectError, vowelsArray, vowelsString} from "../helpers";
-import {drop} from "../../src";
+import {vowelsArray} from "../helpers";
+import {drop, $drop} from "../../src";
 
-describe('#drop', () => {
-  it('should return a new list/string with dropped items from original until length', () => {
-    (<[Parameters<typeof drop>, Slice][]>[
-      [[0, ''], ''],
-      [[0, []], []],
-      [[1, ''], ''],
-      [[1, []], []],
-    ].concat(
-      vowelsArray
-        .map((_, ind) => [
-          [ind, vowelsArray],
-          vowelsArray.slice(ind)
-        ]),
-      vowelsString.split('')
-        .map((_, ind) => [
-          [ind, vowelsString],
-          vowelsString.slice(ind)
-        ])
-    ))
-      .forEach(([args, expected]) => {
-        expectEqual(drop(...args), expected);
+const {stringify} = JSON;
+
+describe('#drop, #$drop', () => {
+  (<[Parameters<typeof drop>, any[]][]>[
+    [[0, []], []],
+    [[1, []], []],
+  ].concat(
+    vowelsArray
+      .map((_, ind) => [
+        [ind, vowelsArray],
+        vowelsArray.slice(ind)
+      ])
+  ))
+    .forEach(([args, expected]) => {
+      it(`drop(${stringify(args)}) === ${stringify(expected)}`, () => {
+        expect(drop(...args)).toEqual(expected);
+        expect($drop(args[0])(args[1])).toEqual(expected);
       });
-  });
+    });
 
-  it('should throw an error when no parameter is passed in', () => {
-    (<any[]>[null, undefined, 0, {}]).forEach(xs =>
-      expectError(() => drop(3, xs))
-    );
+  (<any[]>[null, undefined, 0, {}]).forEach(xs => {
+    it(`should throw when: drop(3, ${xs + ''})`, () => {
+      expect(() => drop(3, xs)).toThrow();
+      expect(() => $drop(3)(xs)).toThrow();
+    });
   });
 });

--- a/packages/fjl/tests/list/test-drop.ts
+++ b/packages/fjl/tests/list/test-drop.ts
@@ -3,8 +3,8 @@ import {expectEqual, expectError, vowelsArray, vowelsString} from "../helpers";
 import {drop} from "../../src";
 
 describe('#drop', () => {
-  it('should return a new list/string with dropped items from original until limit', () => {
-    (<[Parameters<typeof drop>, Slice<any>][]>[
+  it('should return a new list/string with dropped items from original until length', () => {
+    (<[Parameters<typeof drop>, Slice][]>[
       [[0, ''], ''],
       [[0, []], []],
       [[1, ''], ''],
@@ -25,6 +25,7 @@ describe('#drop', () => {
         expectEqual(drop(...args), expected);
       });
   });
+
   it('should throw an error when no parameter is passed in', () => {
     (<any[]>[null, undefined, 0, {}]).forEach(xs =>
       expectError(() => drop(3, xs))

--- a/packages/fjl/tests/list/test-dropWhile.ts
+++ b/packages/fjl/tests/list/test-dropWhile.ts
@@ -4,9 +4,9 @@ import {UnaryPred} from "../../src/types";
 
 describe('#dropWhile', () => {
   const alnumRegex = /^[a-z]$/i,
-    alnumPred = (x): boolean => alnumRegex.test(x),
-    nonAlnumPred = (x): boolean => !alnumPred(x),
-    getCharCodeLessThan = (lessThanCharCode): UnaryPred<any> => {
+    alnumPred = (x: any): boolean => alnumRegex.test(x),
+    nonAlnumPred = (x: any): boolean => !alnumPred(x),
+    getCharCodeLessThan = (lessThanCharCode: any): UnaryPred<any> => {
       const methodName = `charCodeLessThan${lessThanCharCode}`;
       return {
         [methodName]: (x): boolean => (x + '').charCodeAt(0) < lessThanCharCode
@@ -29,4 +29,10 @@ describe('#dropWhile', () => {
         expect(result).toEqual(expected);
       });
     });
+
+  [null, undefined, 0, {}].forEach(x =>
+    it(`should throw an error when: \`dropWhile(() => null, ${x + ''})\``, () => {
+      expect(() => dropWhile(() => null, x as Iterable<any>)).toThrow()
+    })
+  );
 });

--- a/packages/fjl/tests/list/test-take.ts
+++ b/packages/fjl/tests/list/test-take.ts
@@ -1,35 +1,29 @@
-import {expectEqual, expectError, vowelsArray, vowelsString} from "../helpers";
+import {vowelsArray} from "../helpers";
 import {take} from "../../src/list/take";
-import {Slice} from "../../src/types/data";
+
+const {stringify} = JSON;
 
 describe('#take', () => {
-  it('should return taken items from list and/or string until limit', () => {
-    type TakeTest = [[number, string | any[]], string | any[]];
-    type TakeTestCases = Array<TakeTest>;
-    (<TakeTestCases>[
-      [[0, ''], ''],
-      [[0, []], []],
-      [[1, ''], ''],
-      [[1, []], []],
-    ]).concat(
-      (<TakeTestCases>vowelsArray
-        .map((_, ind) => [
-          [ind, vowelsArray],
-          vowelsArray.slice(0, ind)
-        ])),
-      (<TakeTestCases>vowelsString.split('')
-        .map((_, ind) => [
-          [ind, vowelsString],
-          vowelsString.slice(0, ind)
-        ]))
-    )
-      .forEach(([args, expected]) => {
-        expectEqual(take(...args), expected);
+  type TakeTest = [[number, string | any[]], string | any[]];
+  type TakeTestCases = Array<TakeTest>;
+  (<TakeTestCases>[
+    [[0, []], []],
+    [[1, []], []],
+  ]).concat(
+    (<TakeTestCases>vowelsArray.map((_, ind) => [
+      [ind, vowelsArray],
+      vowelsArray.slice(0, ind)
+    ])),
+  )
+    .forEach(([args, expected]) => {
+      it(`take(${stringify(args)}) === ${stringify(expected)}`, () => {
+        expect(take(...args)).toEqual(expected);
       });
-  });
-  it('should throw an error when no parameter is passed in', () => {
-    [null, undefined, 0, {}].forEach(x =>
-      expectError(() => take(3, x as Slice<any>))
-    );
-  });
+    });
+
+  [null, undefined, 0, {}].forEach(x =>
+    it(`should throw an error when: \`take(3, ${x + ''})\``, () => {
+        expect(() => take(3, x as Iterable<any>)).toThrow()
+      })
+  );
 });

--- a/packages/fjl/tests/list/test-takeWhile.ts
+++ b/packages/fjl/tests/list/test-takeWhile.ts
@@ -1,31 +1,37 @@
 import {
   alphabetArray,
-  alphabetString,
   isVowel,
-  nonAlphaNums,
   nonAlphaNumsArray,
   vowelsArray,
-  vowelsString
 } from "../helpers";
-import {range} from "../../src/list/range";
 import {takeWhile} from "../../src/list";
 
+const {stringify} = JSON;
+
 describe('#takeWhile', () => {
-  it('should take elements while predicate is fulfilled and vice-versa', () => {
-    (<[Parameters<typeof takeWhile>, ReturnType<typeof takeWhile>][]>[
-      [[isVowel, vowelsString], vowelsString],
-      [[isVowel, vowelsArray], vowelsArray],
-      [[isVowel, alphabetString], 'a'],
-      [[isVowel, alphabetArray], ['a']],
-      [[isVowel, range(0, 5)], []],
-      [[isVowel, nonAlphaNums], ''],
-      [[isVowel, nonAlphaNumsArray], []],
-      [[isVowel, ''], ''],
-      [[isVowel, []], []],
-    ])
-      .forEach(([args, expected]) => {
+  function* numRange() {
+    let i = 0;
+    while (i++ <= 5) {
+      yield i;
+    }
+  }
+
+  (<[Parameters<typeof takeWhile>, ReturnType<typeof takeWhile>][]>[
+    [[isVowel, vowelsArray], vowelsArray],
+    [[isVowel, alphabetArray], ['a']],
+    [[isVowel, numRange()], []],
+    [[isVowel, nonAlphaNumsArray], []],
+    [[isVowel, []], []],
+  ])
+    .forEach(([args, expected]) => {
+      it(`takeWhile(isVowel, ${stringify(args.slice(1))}) === ${stringify(expected)}`, () => {
         expect(takeWhile(args[0], args[1])).toEqual(expected);
       });
-  });
-  // @todo add failing case(s) here
+    });
+
+  [null, undefined, 0, {}].forEach(x =>
+    it(`should throw when: takeWhile(() => null, ${x + ''})`, () => {
+      expect(() => takeWhile(() => null, x as Iterable<any>)).toThrow()
+    })
+  );
 });


### PR DESCRIPTION
Fixes #87 .