### PR TITLE
docs: move issue grooming plan to md/issues and record it as applied

### DIFF
--- a/md/issues/ISSUE_GROOMING.md
+++ b/md/issues/ISSUE_GROOMING.md
@@ -1,5 +1,11 @@
 # Issue grooming and consolidation plan
 
+> **Status: applied — 2026-07-31.** Every action below has been executed against
+> `functional-jslib/fjl`. The `v2.0` and `Backlog (post-2.0)` milestones exist,
+> #61 and #55 are closed, #124 and #125 are filed, and #113/#114/#116 are real
+> GitHub sub-issues of #32. Two deviations found during execution are recorded
+> in [Deviations on application](#deviations-on-application).
+
 A ready-to-apply pass over the repository's open issues: consolidate the
 overlapping typing-cleanup tickets into one epic, dress the under-described
 issues with acceptance criteria, close the stale ones, and normalize labels and
@@ -17,6 +23,7 @@ milestoned, and carries acceptance criteria.
 
 ## Contents
 
+- [Deviations on application](#deviations-on-application)
 - [Findings that change the plan](#findings-that-change-the-plan)
 - [1. Label and milestone prerequisites](#1-label-and-milestone-prerequisites)
 - [2. Close](#2-close)
@@ -27,6 +34,30 @@ milestoned, and carries acceptance criteria.
 - [7. New issues to file](#7-new-issues-to-file)
 - [8. Rewrite the #57 tracking issue](#8-rewrite-the-57-tracking-issue)
 - [Summary table](#summary-table)
+
+## Deviations on application
+
+Two places where the plan as written was internally inconsistent, and what was
+applied instead.
+
+### `_platform/` is **not** ticked on #32's checklist
+
+Section 3's proposed #32 body ticks `_platform/`, but its own following note
+says the ticks are the union of the pre-consolidation #32 and #61 bodies —
+neither of which ticks it. Verification settles it: `_platform/object/index.ts`
+still takes `any` (`instanceOf`, `$instanceOf`) and `_platform/slice/index.ts`
+still depends on `Slice` and returns `any`. It was left unticked, with the
+reason recorded in the issue body. `_platform/` *is* correctly ticked on #122,
+which measures behaviour, not typing — exactly the distinction section 4 argues
+for.
+
+### #101 keeps its `enhancement` label alongside `ci/cd`
+
+The summary table gives #101 the single type label `ci/cd` while giving #102
+both `enhancement` and `ci/cd`, though the two issues are the same kind of
+ticket. Rather than make near-identical issues inconsistent, both kept
+`enhancement` + `ci/cd`. If the one-type-label rule is to be enforced strictly,
+drop `enhancement` from both, not just #101.
 
 ## Findings that change the plan
 
@@ -197,7 +228,7 @@ Labels: `enhancement`, `tech-debt`, `groomed`, `epic`. Milestone: v2.0.
 >
 > A module is ticked only when **sources + tests + docs** are all done.
 >
-> - [x] `_platform/`
+> - [ ] `_platform/` (see [Deviations](#deviations-on-application))
 > - [x] `boolean/`
 > - [ ] `errorThrowing/`
 > - [x] `function/`
@@ -437,12 +468,12 @@ Backlog milestone.
 
 ## 7. New issues to file
 
-### v2.0 — Add tests asserting curried methods are actually curried
+### v2.0 — Add tests asserting curried methods are actually curried — filed as #124
 
 Labels `enhancement`, `groomed`. Milestone v2.0. This is the one remaining #57
 item with no ticket of its own; #57's rewritten body references it.
 
-### Audit the 2024 "done" batch for mis-ticked issues
+### Audit the 2024 "done" batch for mis-ticked issues — filed as #125
 
 Labels `tech-debt`, `groomed`. Milestone v2.0.
 
@@ -507,7 +538,7 @@ Labels `enhancement`, `epic`. Milestone v2.0.
 
 | Issue | Action | Type label | State | Milestone |
 | --- | --- | --- | --- | --- |
-| #57 | Rewrite as thin index | `enhancement`, `epic` | — | v2.0 |
+| #57 | Rewrite as thin index | `enhancement`, `epic` | `groomed` | v2.0 |
 | #32 | Retitle to epic; canonical checklist | `enhancement`, `tech-debt`, `epic` | `groomed` | v2.0 |
 | #113 | Re-parent under #32 | `enhancement`, `tech-debt` | `groomed` | v2.0 |
 | #114 | Re-parent; add `Slice` criteria + consumers | `tech-debt` | `groomed` | v2.0 |
@@ -516,9 +547,9 @@ Labels `enhancement`, `epic`. Milestone v2.0.
 | #121 | Write body; `replicate`/`unfoldr` remain | `enhancement` | `groomed` | v2.0 |
 | #118 | Write body; workflow triggers | `ci/cd` | `groomed` | v2.0 |
 | #102 | Confirm criteria | `enhancement`, `ci/cd` | `groomed` | v2.0 |
-| #101 | Confirm still valid | `ci/cd` | `groomed` | v2.0 |
-| *(new)* | Curried-method tests | `enhancement` | `groomed` | v2.0 |
-| *(new)* | Audit the 2024 "done" batch | `tech-debt` | `groomed` | v2.0 |
+| #101 | Confirm still valid | `enhancement`, `ci/cd` | `groomed` | v2.0 |
+| #124 | Curried-method tests | `enhancement` | `groomed` | v2.0 |
+| #125 | Audit the 2024 "done" batch | `tech-debt` | `groomed` | v2.0 |
 | #61 | **Close** — duplicate of #32 | — | — | — |
 | #55 | **Close** — obsolete/not planned | — | — | — |
 | #120 | Write body; post-2.0 feature | `enhancement`, `wishlist` | `groomed` | Backlog |


### PR DESCRIPTION
Moves `.github/ISSUE_GROOMING.md` to `md/issues/ISSUE_GROOMING.md` and records the plan as executed.

The document changed from a proposal into a record — the grooming pass it describes has been applied to this repository's issue tracker.

## What was applied to the tracker

- **Prerequisites** — `epic` label created (`#5319E7`); descriptions added to the colour-only labels `needs-grooming`, `needs-triage`, `ci/cd`, `tech-debt`; `v2.0` and `Backlog (post-2.0)` milestones created.
- **Closed** — #61 as a duplicate of #32, #55 as not planned.
- **Filed** — #124 (tests asserting curried methods are actually curried) and #125 (audit the 2024 "done" batch for mis-ticked issues).
- **Consolidated** — #32 retitled to *v2.0 - Type system cleanup (epic)* and given the single canonical per-module checklist; #113, #114, and #116 attached to it as real GitHub sub-issues rather than body references.
- **Dressed** — #114, #116, #121, #118, #120, #78, #41, #38, #103, #20 given acceptance criteria; #122 rescoped to a behavioural review explicitly distinct from #32's typing pass; #57 rewritten as a thin index.

Net effect: 18 open issues → 18, sorted into a focused **12-issue v2.0 milestone** and a **6-issue backlog**. Every open issue now carries labels and a milestone.

## Deviations from the plan as written

A new *Deviations on application* section documents the two places the plan contradicted itself, and what was applied instead:

1. **`_platform/` is left unticked on #32's typing checklist.** Section 3's proposed body ticked it, but its own following note says the ticks are the union of the pre-consolidation #32 and #61 bodies — neither of which ticks it. Verification agrees: `_platform/object/index.ts` still takes `any` and `_platform/slice/index.ts` still depends on `Slice`. Ticking it would have reproduced exactly the mis-tick problem #125 exists to catch. It remains ticked on #122, which measures behaviour rather than typing.
2. **#101 keeps `enhancement` alongside `ci/cd`.** The summary table gave #101 one type label but #102 two, for two issues of the same kind. Both kept `enhancement` + `ci/cd` rather than being made inconsistent with each other.

Also verified while applying: #116's final criterion is genuinely done — `packages/fjl/src/types/README.md` documents the positional-vs-named generic convention — so that box is correctly ticked.

## Test plan

Documentation only; no source changes. The pre-push hook ran the full build and suite: **133 test suites / 1066 tests passing**.

Note that this PR runs no CI — `.github/workflows/monorepo-build.yml` still triggers only on the `monorepo` branch, which is what #118 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
