### PR TITLE
ci(docs): #102-docs-strategy generate API reference with TypeDoc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/node_modules/**/*
 **/dist/**/*
 **/coverage/**/*
+**/docs-dist/**/*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,70 @@
+# Builds the TypeDoc API reference and publishes it to GitHub Pages.
+#
+# Triggered on the same event `publish.yml` uses (`release: [created]`), so the
+# published docs always describe the release that just went to npm. Also
+# runnable by hand via `workflow_dispatch`.
+#
+# Rendering strategy and the reasoning behind it:
+#   md/adr/0001-documentation-generation-strategy.md
+#
+# NOTE: this deploys only once GitHub Pages' build source is set to
+# "GitHub Actions" (Settings > Pages > Build and deployment > Source).
+
+name: Docs
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+# Allow the workflow to publish to Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deploys race; let a newer release supersede an in-flight run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: CI/CD
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm i
+      # TypeDoc reads `packages/*/src`, not `dist/`, so no build step is needed.
+      # `run` is required - bare `pnpm docs` is swallowed by npm's built-in
+      # `docs` command (pnpm forwards unknown commands to npm) and is a no-op.
+      - run: pnpm run docs
+      - name: Verify docs were generated
+        run: |
+          test -f docs-dist/index.html || {
+            echo "::error::docs-dist/index.html missing - TypeDoc produced no output"
+            exit 1
+          }
+          echo "Generated $(find docs-dist -type f | wc -l) files."
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs-dist
+
+  deploy-docs:
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 **/dist
 **/docs
 
+# Generated API reference (TypeDoc) - see md/adr/0001-documentation-generation-strategy.md
+**/docs-dist
+
 # Files
 .claude/settings.local.json
 *.log

--- a/md/adr/0001-documentation-generation-strategy.md
+++ b/md/adr/0001-documentation-generation-strategy.md
@@ -1,0 +1,289 @@
+# ADR 0001 — Documentation generation strategy
+
+- **Status:** Accepted
+- **Date:** 2026-07-31
+- **Issue:** [#102 — CI/CD: Choose documentation generating strategy](https://github.com/functional-jslib/fjl/issues/102)
+- **Decision:** Generate the API reference with **TypeDoc**, from TypeScript
+  sources, into a gitignored `docs-dist/`, and publish it to GitHub Pages from a
+  `Release`-triggered workflow.
+
+## Context
+
+`fjl` is a pnpm-8 workspace monorepo with six packages, four of which are
+published to npm and have a `src/index.ts`:
+
+| package | published | built by `rollup.config.mjs` | has `src/index.ts` |
+| --- | --- | --- | --- |
+| `fjl` | yes | yes | yes |
+| `fjl-validator` | yes | yes | yes |
+| `fjl-inputfilter` | yes | yes | yes |
+| `fjl-validator-recaptcha` | yes | **no** (commented out of `projectNames`) | yes |
+| `fjl-filter` | no | no | no |
+| `fjl-labs` | no | no | no |
+
+The sources are TypeScript 5.4 and carry TSDoc-style block comments in 158 of
+175 `.ts` files under `packages/fjl/src/`. The toolchain is Node-only
+(rollup 2, jest/ts-jest, eslint 8), CI runs Node 18/20/22 on `ubuntu-latest`,
+and releases go out from `.github/workflows/publish.yml` on the
+`release: [created]` event.
+
+Issue #102 proposed Deno as the initial recommendation. There is already a
+`deno.json` at the repository root, and an untracked `docs/` directory dated
+2024-05-28 containing `all_symbols.html`, `fuse.js`, `search_index.js`,
+`styles.css` — the unmistakable output signature of `deno doc --html`. So the
+Deno path was not only proposed, it was tried.
+
+### The existing `docs/` output is empty
+
+The single most important finding of this analysis. The committed-to-disk
+artifact of the previous `deno doc` run contains:
+
+```js
+// docs/search_index.js  (2024-05-28)
+(function () {
+  window.DENO_DOC_SEARCH_INDEX = {"nodes":[]};
+})()
+```
+
+```html
+<!-- docs/all_symbols.html -->
+<main><div class="space-y-7" id=""></div></main>
+```
+
+Zero symbols. The tool exited successfully and produced a complete-looking
+eight-file site that documents nothing. Reproduced today with Deno 2.4.2:
+
+```console
+$ deno doc --html --name=fjl --output=./deno-out packages/fjl/src/index.ts
+Written 13 files to "./deno-out"
+
+$ grep -o '"name":"[^"]*"' ./deno-out/search_index.js | wc -l
+0
+```
+
+The cause is that `fjl` uses extensionless relative imports throughout
+(`import {reduce} from "../list/utils"`), which Deno's resolver rejects. The
+failure is silent: `deno doc` reports success and emits an empty site. The
+maintainer's own scaffolding note on `origin/feat/#55/deno_support`
+(`node_scripts/tasks/fjl-deno.json.mjs`, commit `ad4076b5`) confirms this was
+the known blocker — it is a stub whose entire body is a comment describing an
+unwritten script to synthesize `deno.json.imports` entries so that
+"all source imports work as they are (without file extensions)".
+
+## Options considered
+
+All three were run against this working tree, not evaluated from documentation.
+
+### 1. `deno doc --html`
+
+Works only with `--unstable-sloppy-imports`, which makes Deno tolerate the
+extensionless imports:
+
+```console
+$ deno doc --unstable-sloppy-imports --html --name=fjl \
+    --output=./deno-sloppy packages/fjl/src/index.ts
+Written 465 files to "./deno-sloppy"
+
+$ grep -o '"name":"[^"]*"' ./deno-sloppy/search_index.js | wc -l
+452
+```
+
+That fixes the single-package case. The multi-package case does not work at
+all:
+
+```console
+$ deno doc --unstable-sloppy-imports --html --name=fjl --output=./deno-multi \
+    packages/fjl/src/index.ts packages/fjl-validator/src/index.ts \
+    packages/fjl-inputfilter/src/index.ts \
+    packages/fjl-validator-recaptcha/src/index.ts
+
+Warning Relative import path "querystring" not prefixed with / or ./ or ../
+  hint: If you want to use a built-in Node module, add a "node:" prefix.
+    at .../packages/fjl-validator-recaptcha/src/index.ts:10:25
+Warning Relative import path "https" not prefixed with / or ./ or ../
+    at .../packages/fjl-validator-recaptcha/src/index.ts:9:19
+error: Failed resolving 'https' from '.../fjl-validator-recaptcha/src/index.ts'
+```
+
+Hard failure, no output. `fjl-validator-recaptcha` imports the Node builtins
+`https` and `querystring` without the `node:` prefix Deno requires.
+
+Beyond the resolution problems, `deno doc` has no concept of packages: multiple
+entry points are flattened into one namespace, so a four-package monorepo would
+render as one undifferentiated symbol list. And adopting it puts a second
+language runtime in the release pipeline for the sole purpose of rendering docs.
+
+Adopting Deno would require: prefixing Node builtins with `node:` across
+`fjl-validator-recaptcha`, permanently depending on an unstable Deno flag (or
+writing and maintaining the import-map generator that #55 left as a stub),
+accepting a flat single-namespace site, and installing Deno in CI.
+
+### 2. TypeDoc
+
+Ran clean on all four published packages on the first attempt, from sources,
+with no prior build and no warnings:
+
+```console
+$ pnpm run docs
+
+> fjl-monorepo@0.0.0 docs /home/edlc/workspace/functional-jslib/fjl
+> typedoc
+
+info Documentation generated at ./docs-dist
+
+real    0m2.011s
+```
+
+(Use `pnpm run docs`, not bare `pnpm docs` — pnpm forwards unrecognized
+commands to npm, and `npm docs` is a real command that opens a package homepage,
+so `pnpm docs` silently exits 0 without generating anything.)
+
+502 files: four `modules/` pages (`fjl`, `fjlValidator`, `fjlInputFilter`,
+`fjlValidatorReCaptcha`) and 489 symbol pages — 386 functions, 70 types,
+18 interfaces, 11 variables, 2 classes, 2 enums.
+It reads the existing TSDoc comments, resolves cross-package imports (via
+`paths` in `tsconfig.docs.json`, so no build step is needed), renders `$`-prefixed
+curried variants with their real names, and links every symbol back to its
+source line on GitHub.
+
+It reuses the toolchain that is already installed — it is a devDependency
+resolved by the same `pnpm i` CI already runs, and it consumes the same
+TypeScript 5.4 the build and tests use.
+
+### 3. api-extractor + api-documenter
+
+Also run for real, against `packages/fjl/dist/esm/index.d.ts` after a full
+`pnpm build`:
+
+```console
+$ pnpm dlx @microsoft/api-extractor@7 run --local --config ./api-extractor.probe.json
+Warning: dist/esm/types/arity.d.ts:9:1 - (ae-missing-release-tag) "UnitNary" is
+  part of the package's API, but it is missing a release tag (@alpha, @beta,
+  @public, or @internal)
+  ... 415 more ...
+API Extractor completed successfully
+
+$ ls -la ./ae-out/
+-rw-r--r-- 832137 fjl.api.json
+```
+
+It works, but the cost is disproportionate:
+
+- **416 `ae-missing-release-tag` warnings for `fjl` alone.** Silencing them
+  means annotating every exported symbol with `@public`/`@beta`; suppressing
+  them means the release-tag machinery — api-extractor's main reason to exist —
+  is switched off.
+- **It requires a build.** It reads `.d.ts`, so `pnpm build` must run first.
+  `fjl-validator-recaptcha` is commented out of `rollup.config.mjs`, so the
+  fourth published package cannot be documented at all without first fixing the
+  build.
+- **It does not render a site.** The output is `fjl.api.json`; rendering needs
+  api-documenter (Markdown only) plus a static-site generator — a three-stage
+  pipeline, one config file per package, no cross-package linking.
+
+api-extractor's real value is API-surface review and `.d.ts` rollup — release
+gating, not reference docs. That is a legitimate future need for this repo
+(see follow-ups), but it is a different problem from #102.
+
+## Comparison
+
+| | `deno doc` | **TypeDoc** | api-extractor + api-documenter |
+| --- | --- | --- | --- |
+| Documents all 4 published packages | **no** — hard error on `fjl-validator-recaptcha` | **yes** | needs 1 config/package; `fjl-validator-recaptcha` impossible (not built) |
+| Symbols extracted (single run) | 452 (`fjl` only, with unstable flag) | **489** across 4 packages | 416+ (`fjl` only, as JSON) |
+| Reads existing TSDoc comments | partial | partial (same limitation, see below) | yes |
+| Reads sources directly | yes | **yes** | no — requires `pnpm build` first |
+| Renders a browsable site | yes | **yes** | no — JSON → Markdown → SSG |
+| Multi-package structure | flat, single namespace | **one module per package** | one isolated JSON per package |
+| Extra toolchain in CI | **Deno runtime** | none — a devDependency | none, but 3 tools |
+| Unstable flags required | `--unstable-sloppy-imports` | none | none |
+| Warnings on this codebase | resolution warnings | **0** | 416 |
+| Wall time | sub-second (`fjl` only) | ~2s (all 4) | ~30s + full build |
+| Source changes required first | `node:` prefixes; import map | **none** | 416 release-tag annotations |
+
+## Decision
+
+**TypeDoc.**
+
+The deciding reasons, in order:
+
+1. **It is the only option that documents all four published packages.**
+   `deno doc` errors out on `fjl-validator-recaptcha`; api-extractor cannot see
+   it because rollup does not build it.
+2. **It needs no source changes to work today.** The other two both require
+   editing library sources before they produce anything — `node:` prefixes and
+   an import map for Deno, 416 release-tag annotations for api-extractor.
+3. **It reads sources, not build output**, so `pnpm docs` is independent of
+   `pnpm build` and cannot publish docs for a stale `dist/`.
+4. **It adds no new runtime to CI.** It is a devDependency installed by the
+   `pnpm i` the release workflow already runs; Deno would be a second language
+   toolchain maintained solely for docs.
+5. **It models the monorepo.** Four `modules/` entries, cross-linked, versus one
+   flat namespace.
+
+The empirical record also matters: the Deno path was attempted here in May 2024
+and shipped an empty site that nobody noticed for two years. That is not an
+argument that Deno is a bad tool — it is an argument that this codebase's import
+style and Deno's resolver are a poor fit, and that the failure mode is silent.
+
+### Known limitation, shared by all candidates
+
+Neither TypeDoc nor `deno doc` attaches a doc comment that sits *inside* a
+multi-declarator `export const` list:
+
+```ts
+export const
+
+  /**
+   * Filters given slice ... using given predicate (`pred`).
+   */
+  filter = <T>(pred: TernaryPred<T, number, T[]>, xs: T[]): T[] => { /* ... */ },
+```
+
+115 files use this shape, and their descriptions are dropped by both tools.
+The classic placement works everywhere:
+
+```ts
+/**
+ * Maps a function over an objects own key, and values.
+ */
+export const mapObj = <T extends object>(fn: MapOp, obj: T): T => /* ... */
+```
+
+This is a source-comment-placement problem, not a tool-selection one — it costs
+the same under either renderer, so it does not discriminate between the options.
+Filed as a follow-up.
+
+## Consequences
+
+- `typedoc` is added as a root devDependency; `typedoc.json` and
+  `tsconfig.docs.json` are added at the root; `pnpm run docs` builds the site.
+- Output goes to **`docs-dist/`**, gitignored and eslint-ignored. It
+  deliberately does *not* reuse the legacy `docs/` path, which still holds the
+  2024 `deno doc` output on the maintainer's checkout.
+- `.github/workflows/docs.yml` builds and deploys `docs-dist/` to GitHub Pages
+  on `release: [created]`, matching the trigger `publish.yml` already uses, plus
+  a `workflow_dispatch` for manual runs.
+- Docs regeneration is decoupled from `pnpm build`, so a docs failure cannot
+  break a release build and vice versa.
+- GitHub Pages must be switched to the "GitHub Actions" source once, by hand,
+  before the workflow can deploy. Until then the workflow builds and uploads the
+  artifact and the deploy step fails loudly.
+
+## Follow-ups
+
+1. **Delete the legacy `docs/` directory.** It is `deno doc` output from
+   2024-05-28 containing zero symbols, matched by the `**/docs` line in
+   `.gitignore` (so it is untracked), and its vendored `fuse.js` / `script.js` /
+   `search.js` are the source of most of the repo's eslint errors. Not removed
+   in this change, deliberately.
+2. **Normalize doc-comment placement** in the 115 files that put `/** */` inside
+   a multi-declarator `export const`, so the prose actually reaches the site.
+3. **Add `node:` prefixes** to `https` / `querystring` in
+   `packages/fjl-validator-recaptcha/src/index.ts`. Correct regardless of the
+   docs decision, and it unblocks Deno consumers.
+4. **Re-enable `fjl-validator-recaptcha` in `rollup.config.mjs`** — it is
+   published but not built.
+5. **Reconsider api-extractor for API-surface review**, separately from docs:
+   `.d.ts` rollup and a reviewed `.api.md` report would catch accidental
+   breaking changes at release time.

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "ts-node": "^10.9.2",
     "tsc-files": "^1.1.4",
     "tslib": "^2.6.2",
+    "typedoc": "^0.25.13",
     "typescript": "^5.4.5"
   },
   "scripts": {
     "build": "rollup --config rollup.config.mjs",
+    "docs": "typedoc",
     "eslint": "eslint -c .eslintrc.json .",
     "link-packages": "node node_scripts/tasks/link-packages.mjs",
     "lint": "pnpm eslint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
+      typedoc:
+        specifier: ^0.25.13
+        version: 0.25.13(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -1489,6 +1492,10 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
+    dev: true
+
+  /ansi-sequence-parser@1.1.3:
+    resolution: {integrity: sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==}
     dev: true
 
   /ansi-styles@3.2.1:
@@ -3959,6 +3966,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+    dev: true
+
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -4137,6 +4148,10 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: true
+
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -4152,6 +4167,12 @@ packages:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
       tmpl: 1.0.5
+    dev: true
+
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
     dev: true
 
   /media-typer@0.3.0:
@@ -4876,6 +4897,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /shiki@0.14.7:
+    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
+    dependencies:
+      ansi-sequence-parser: 1.1.3
+      jsonc-parser: 3.3.1
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: true
+
   /side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
@@ -5309,6 +5339,20 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /typedoc@0.25.13(typescript@5.4.5):
+    resolution: {integrity: sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.4
+      shiki: 0.14.7
+      typescript: 5.4.5
+    dev: true
+
   /typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
@@ -5390,6 +5434,14 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: true
+
+  /vscode-textmate@8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
 
   /wait-on@7.2.0:

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "fjl": ["./packages/fjl/src/index.ts"],
+      "fjl-validator": ["./packages/fjl-validator/src/index.ts"],
+      "fjl-inputfilter": ["./packages/fjl-inputfilter/src/index.ts"],
+      "fjl-validator-recaptcha": ["./packages/fjl-validator-recaptcha/src/index.ts"]
+    }
+  },
+  "include": [
+    "packages/fjl/src/**/*.ts",
+    "packages/fjl-validator/src/**/*.ts",
+    "packages/fjl-inputfilter/src/**/*.ts",
+    "packages/fjl-validator-recaptcha/src/**/*.ts"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/dist",
+    "**/tests"
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "name": "fjl",
+  "entryPoints": [
+    "packages/fjl/src/index.ts",
+    "packages/fjl-validator/src/index.ts",
+    "packages/fjl-inputfilter/src/index.ts",
+    "packages/fjl-validator-recaptcha/src/index.ts"
+  ],
+  "entryPointStrategy": "resolve",
+  "tsconfig": "./tsconfig.docs.json",
+  "out": "docs-dist",
+  "readme": "./README.md",
+  "includeVersion": false,
+  "githubPages": false,
+  "hideGenerator": false,
+  "excludeExternals": true,
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "sort": ["alphabetical"],
+  "categorizeByGroup": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/functional-jslib/fjl",
+    "npm": "https://www.npmjs.com/package/fjl"
+  },
+  "validation": {
+    "notExported": false,
+    "invalidLink": false,
+    "notDocumented": false
+  }
+}


### PR DESCRIPTION
## Summary

Chooses **TypeDoc** as the documentation rendering strategy for the monorepo, implements it, and adds a release-triggered GitHub Pages publish workflow.

All three candidates were **run against this working tree**, not evaluated from their docs. The result overturns the issue's initial recommendation.

Closes #102

**Work unit:** `102-docs-strategy`

---

## The finding that decided it

The repo already has an untracked `docs/` directory at root, dated 2024-05-28, matched by the `**/docs` line in `.gitignore`. Its file signature (`all_symbols.html`, `fuse.js`, `search_index.js`, `styles.css`) identifies it as `deno doc --html` output — so the Deno path in this issue was not just proposed, it was tried.

It documents nothing:

```js
// docs/search_index.js  (2024-05-28)
(function () {
  window.DENO_DOC_SEARCH_INDEX = {"nodes":[]};
})()
```
```html
<!-- docs/all_symbols.html -->
<main><div class="space-y-7" id=""></div></main>
```

Reproduced today with Deno 2.4.2 — the tool exits **successfully** and emits a complete-looking 13-file site with zero symbols:

```console
$ deno doc --html --name=fjl --output=./deno-out packages/fjl/src/index.ts
Written 13 files to "./deno-out"

$ grep -o '"name":"[^"]*"' ./deno-out/search_index.js | wc -l
0
```

Cause: `fjl` uses extensionless relative imports (`import {reduce} from "../list/utils"`) throughout, which Deno's resolver rejects — silently, for `deno doc`. The maintainer's own note on `origin/feat/#55/deno_support` (`node_scripts/tasks/fjl-deno.json.mjs`, commit `ad4076b5`) confirms this was the known blocker; it's a stub whose whole body is a comment describing an unwritten script to synthesize `deno.json.imports` so "all source imports work as they are (without file extensions)".

## Options, as actually run

### `deno doc`

`--unstable-sloppy-imports` fixes the single-package case:

```console
$ deno doc --unstable-sloppy-imports --html --name=fjl \
    --output=./deno-sloppy packages/fjl/src/index.ts
Written 465 files to "./deno-sloppy"

$ grep -o '"name":"[^"]*"' ./deno-sloppy/search_index.js | wc -l
452
```

The multi-package case fails outright:

```console
$ deno doc --unstable-sloppy-imports --html --name=fjl --output=./deno-multi \
    packages/fjl/src/index.ts packages/fjl-validator/src/index.ts \
    packages/fjl-inputfilter/src/index.ts \
    packages/fjl-validator-recaptcha/src/index.ts

Warning Relative import path "querystring" not prefixed with / or ./ or ../
  hint: If you want to use a built-in Node module, add a "node:" prefix.
    at .../packages/fjl-validator-recaptcha/src/index.ts:10:25
Warning Relative import path "https" not prefixed with / or ./ or ../
    at .../packages/fjl-validator-recaptcha/src/index.ts:9:19
error: Failed resolving 'https' from '.../fjl-validator-recaptcha/src/index.ts'
```

No output. `fjl-validator-recaptcha` imports the Node builtins `https` and `querystring` without the `node:` prefix Deno requires. `deno doc` also has no concept of packages — multiple entry points flatten into one namespace.

### api-extractor + api-documenter

Run for real against `packages/fjl/dist/esm/index.d.ts` after a full `pnpm build`:

```console
$ pnpm dlx @microsoft/api-extractor@7 run --local --config ./api-extractor.probe.json
Warning: dist/esm/types/arity.d.ts:9:1 - (ae-missing-release-tag) "UnitNary" is
  part of the package's API, but it is missing a release tag (@alpha, @beta,
  @public, or @internal)
  ... 415 more ...
API Extractor completed successfully

$ ls -la ./ae-out/
-rw-r--r-- 832137 fjl.api.json
```

416 `ae-missing-release-tag` warnings for `fjl` alone; requires a build (and `fjl-validator-recaptcha` is commented out of `rollup.config.mjs`, so it can't be documented at all); produces JSON, not a site — rendering needs api-documenter (Markdown) plus an SSG.

### TypeDoc

Clean on all four published packages, first attempt, from sources, no build, zero warnings. See evidence below.

## Comparison

| | `deno doc` | **TypeDoc** | api-extractor + api-documenter |
| --- | --- | --- | --- |
| Documents all 4 published packages | **no** — hard error on `fjl-validator-recaptcha` | **yes** | needs 1 config/package; `fjl-validator-recaptcha` impossible (not built) |
| Symbols extracted (single run) | 452 (`fjl` only, w/ unstable flag) | **489** across 4 packages | 416+ (`fjl` only, as JSON) |
| Reads sources directly | yes | **yes** | no — requires `pnpm build` first |
| Renders a browsable site | yes | **yes** | no — JSON → Markdown → SSG |
| Multi-package structure | flat, single namespace | **one module per package** | one isolated JSON per package |
| Extra toolchain in CI | **Deno runtime** | none — a devDependency | none, but 3 tools |
| Unstable flags required | `--unstable-sloppy-imports` | **none** | none |
| Warnings on this codebase | resolution warnings | **0** | 416 |
| Wall time | sub-second (`fjl` only) | ~2s (all 4) | ~30s + full build |
| Source changes required first | `node:` prefixes; import map | **none** | 416 release-tag annotations |

## Decision: TypeDoc

1. **Only option that documents all four published packages.** `deno doc` errors on `fjl-validator-recaptcha`; api-extractor can't see it because rollup doesn't build it.
2. **Needs no source changes to work today.** The other two both require editing library sources before producing anything.
3. **Reads sources, not build output** — `pnpm run docs` is independent of `pnpm build`, so it can't publish docs for a stale `dist/`.
4. **No new runtime in CI** — a devDependency installed by the `pnpm i` the release workflow already runs, using the same TypeScript 5.4 as build and tests.
5. **Models the monorepo** — four cross-linked `modules/` entries.

Full reasoning: [`md/adr/0001-documentation-generation-strategy.md`](md/adr/0001-documentation-generation-strategy.md).

### Known limitation, shared by every candidate

Neither TypeDoc nor `deno doc` picks up a doc comment placed *inside* a multi-declarator `export const` list:

```ts
export const

  /**
   * Filters given slice ... using given predicate (`pred`).
   */
  filter = <T>(pred: TernaryPred<T, number, T[]>, xs: T[]): T[] => { /* ... */ },
```

115 files use this shape and their prose is dropped **by both tools equally** — verified: `fjl.filter` renders without a description under TypeDoc *and* under `deno doc`, while `fjl.mapObj` (classic `/** */ export const` placement) renders correctly under both. It's a source-comment-placement problem, not a tool-selection one. Filed as follow-up 2 below.

## Changes

- `typedoc.json` — 4 entry points (one per published package), output `docs-dist/`, root `README.md` as the landing page, GitHub/npm nav links.
- `tsconfig.docs.json` — docs-only tsconfig; `paths` maps `fjl` / `fjl-validator` / `fjl-inputfilter` / `fjl-validator-recaptcha` to their `src/index.ts`, so cross-package imports resolve without a build.
- `package.json` — adds `typedoc@^0.25.13` devDependency and a `docs` script. Additive only, to stay out of the way of the concurrent `scripts` edit.
- `pnpm-lock.yaml` — regenerated for the new devDependency.
- `.gitignore` / `.eslintignore` — ignore `docs-dist/`. Without the eslint entry, 502 generated files would be linted.
- `.github/workflows/docs.yml` — new. `release: [created]` (matching `publish.yml`) + `workflow_dispatch`; Node 20 / pnpm 8 / `HUSKY: 0`, consistent with the existing workflows; `pages: write` + `id-token: write` OIDC permissions; `concurrency: pages`; a guard step that fails loudly if `docs-dist/index.html` is missing; `upload-pages-artifact` → `deploy-pages`.
- `md/adr/0001-documentation-generation-strategy.md` — the ADR. New `md/adr/` directory alongside the existing `md/issues/`.

### Gotcha worth knowing

**`pnpm docs` does not work — use `pnpm run docs`.** pnpm forwards unrecognized commands to npm, and `npm docs` is a real command (opens a package homepage), so bare `pnpm docs` exits 0 and generates nothing:

```console
$ pnpm docs
npm warn Unknown env config "manage-package-manager-versions". ...
$ ls docs-dist
ls: cannot access 'docs-dist': No such file or directory
```

The workflow uses `pnpm run docs`, and it's noted in the ADR and in a workflow comment.

## Evidence the generator actually ran

```console
$ rm -rf docs-dist && pnpm run docs

> fjl-monorepo@0.0.0 docs /home/edlc/workspace/functional-jslib/fjl
> typedoc

[info] Documentation generated at ./docs-dist
EXIT=0

$ find docs-dist -type f | wc -l
502
$ du -sh docs-dist
4.9M	docs-dist

$ ls docs-dist
assets  classes  enums  functions  hierarchy.html  index.html
interfaces  modules  types  variables

$ ls docs-dist/modules
fjl.html  fjlInputFilter.html  fjlValidator.html  fjlValidatorReCaptcha.html

$ for d in functions types interfaces variables classes enums; do \
    echo "  $d: $(ls docs-dist/$d | wc -l)"; done
  functions: 386
  types: 70
  interfaces: 18
  variables: 11
  classes: 2
  enums: 2
```

489 symbol pages across 4 modules. Rendered content spot-check (tags stripped):

```
### docs-dist/index.html
fjl | GitHub npm | fjl-mono-repo — Mono repo for libraries in the
functional-jslib org. Development / Building — Build commands are defined
on repo root. Testing — Test commands are defined on repo root.

### docs-dist/modules/fjlValidator.html
fjlValidator | fjl ... Module fjlValidator — Defined in
packages/fjl-validator/src/index.ts:1 — Index: Interfaces: LenValidatorMessage
Templates, LenValidatorOptions, MessageTemplates, RegexValidatorOptions,
ValidatorOptions, ValidatorResult — Type Aliases: MessageGetter,
MessageTemplateRValue, Validator — Functions: $alnumValidator, $digitValidator...
```

`$`-prefixed curried variants render under their real names (`$filter`, `$map`); only the filename is sanitized to `_filter.html`.

## Verification

| check | result |
| --- | --- |
| `pnpm run docs` | exit 0, 502 files, 0 warnings |
| `pnpm test` | pass (via `pre-push` hook) |
| `pnpm build` | exit 0 (via `pre-push` hook) |
| `pnpm lint` | **0 errors, 62 warnings** — unchanged from baseline; verified with `docs-dist/` present, confirming the `.eslintignore` entry works |
| `git status` with `docs-dist/` present | clean — correctly gitignored |
| workflow YAML | parses; `jobs: [build-docs, deploy-docs]`, `on: [release, workflow_dispatch]` |

No commit or push hooks were bypassed — `commit-msg`, `pre-commit`, and `pre-push` all ran and passed.

> Note on the lint baseline: the 21 pre-existing errors reported on `main` come from `docs/fuse.js`, `docs/script.js`, and `docs/search.js`. That directory is matched by `**/docs` in `.gitignore` and is therefore **untracked** — it exists only on checkouts where it was generated locally in 2024, which is why a fresh worktree reports 0 errors. This PR doesn't change that either way.

## Manual follow-up required

**GitHub Pages must be enabled before `docs.yml` can deploy.** Deliberately not done here — it's an outward-facing settings mutation on a public repo.

Click-path: **Settings → Pages → Build and deployment → Source → "GitHub Actions"**

Or, for a maintainer with admin scope:

```sh
gh api -X POST repos/functional-jslib/fjl/pages \
  -f 'build_type=workflow'
```

(Use `-X PUT` instead of `-X POST` if Pages is already enabled with a different source.)

Until that's done, `build-docs` succeeds and uploads the artifact while `deploy-docs` fails with a clear Pages-not-enabled error. The workflow is **added, not triggered** — nothing has been published as part of this PR.

## Recommended follow-up issues

1. **Delete the legacy `docs/` directory.** It's `deno doc` output from 2024-05-28 containing zero symbols, and its vendored `fuse.js` / `script.js` / `search.js` are the source of most of the repo's eslint errors on checkouts where it exists. Left untouched here on purpose; the new generator writes to `docs-dist/` specifically to avoid the collision.
2. **Normalize doc-comment placement** across the 115 files that put `/** */` inside a multi-declarator `export const`, so the prose reaches the rendered site. This is the single highest-value change for docs quality and it's renderer-independent.
3. **Add `node:` prefixes** to `https` / `querystring` in `packages/fjl-validator-recaptcha/src/index.ts` — correct regardless of the docs decision, and it unblocks Deno consumers.
4. **Re-enable `fjl-validator-recaptcha` in `rollup.config.mjs`** — it's published to npm but not built.
5. **Reconsider api-extractor for API-surface review**, separately from docs: a reviewed `.api.md` report would catch accidental breaking changes at release time. That's its real strength, and a legitimate future need — just not the problem #102 poses.
