### PR TITLE
feat(fjl): #121-generators add lazy replicateIter/unfoldrIter siblings

### DIFF
--- a/md/issues/GENERATOR_AUDIT.md
+++ b/md/issues/GENERATOR_AUDIT.md
@@ -1,0 +1,143 @@
+# Generator conversion audit — `list/` (#121)
+
+> **Status: applied — 2026-07-31.** `replicate` and `unfoldr` gained lazy
+> siblings (`replicateIter`, `unfoldrIter`); the `scan*`/`zip*`/`unzip*` families
+> were audited and **stay eager**, for the reasons recorded below. No existing
+> return type changed, so the change set is non-breaking.
+
+`fjl` is published (`fjl@2.0.0-alpha.5`), so turning a function that returns
+`T[]` into one that returns a `Generator` is a breaking change for every
+consumer that indexes, `.length`s, `.map`s, or spreads the result. #121's own
+rule governs the whole audit:
+
+> Where a generator would break existing consumers, keep the eager version and
+> add a `*`-suffixed generator sibling rather than changing the return type.
+
+All claims below were verified against the working tree at `61a9632d`
+("Merge pull request #127 from functional-jslib/chore/issue-worktree-fleet-skill").
+
+## Contents
+
+- [Naming](#naming)
+- [The two conversions](#the-two-conversions)
+- [Audit verdicts](#audit-verdicts)
+- [Why the scan family stays eager](#why-the-scan-family-stays-eager)
+- [Why the zip/unzip family stays eager](#why-the-zipunzip-family-stays-eager)
+- [What would unblock the deferred conversions](#what-would-unblock-the-deferred-conversions)
+- [Incidental findings — not fixed here](#incidental-findings--not-fixed-here)
+
+## Naming
+
+`Iter` suffix — `replicateIter`, `unfoldrIter`, curried as `$replicateIter` and
+`$unfoldrIter`.
+
+`*` is not a legal identifier character, so "`*`-suffixed" is read as its
+in-repo realization: `range.ts` already ships eager `range` alongside the
+generator `rangeIter`, and that is the only existing eager/lazy sibling pair in
+the codebase. New pairs follow it rather than inventing a second convention.
+
+Note that `rangeIter` carries an `@todo Rename to 'range'`, i.e. the eventual
+v2 intent is generator-primary naming across the family. When that rename
+happens it should move `range`, `replicate`, and `unfoldr` together, as one
+deliberate breaking change with a migration note — not one function at a time.
+
+## Yield shape
+
+The already-converted generators (`cycle`, `iterate`, `repeat`) do **not** yield
+elements; they yield the *list built so far*, growing by one on each iteration
+(`Generator<T[], void>`). The new siblings follow that exactly, which gives a
+law worth stating:
+
+> The last value a `*Iter` generator yields is (deep) equal to what its eager
+> counterpart returns.
+
+Both properties are asserted in `tests/list/test-replicate.ts` and
+`tests/list/test-unfoldr.ts`. As in `iterate`/`repeat`, the yielded array is the
+same growing reference each time — callers wanting a snapshot must `slice` it.
+This is documented on both new functions.
+
+## The two conversions
+
+| Function | Decision | Reason |
+| --- | --- | --- |
+| `replicate` | Keep eager, add `replicateIter` | Bounded by construction — `n` is finite, so nothing to "stop early" from and no non-termination to avoid. Converting outright would break `.length`/indexing consumers for zero correctness gain. The sibling is still worth having: `replicate` is the bounded form of `repeat`, and `replicateIter(Infinity, x)` degenerates to `repeat(x)` — something eager `replicate` cannot express at all (`Array(Infinity)` throws). |
+| `unfoldr` | Keep eager, add `unfoldrIter` | Laziness is a real fix here: an `op` that never returns `undefined` makes the eager `unfoldr` loop forever, and `unfoldrIter` makes that same `op` consumable. But `unfoldr` has a live in-repo array consumer — `src/list/unzipN.ts` uses its result as a `T[][]` seed — plus `tests/object/index_test.ts`, so changing the return type is a breaking change with an in-tree casualty. Sibling route. |
+
+The eager `unfoldr` is now implemented **in terms of** `unfoldrIter` (it drains
+the generator and returns the last yield), so the two cannot drift apart. Eager
+`replicate` keeps its `Array(n).fill(...)` fast path — the generator is not a
+faster way to fill a fixed-size array.
+
+Both new generators compose with the already generator-friendly `take` /
+`takeWhile` from #87, which accept `Iterable`.
+
+## Audit verdicts
+
+| Function | Verdict | Rationale |
+| --- | --- | --- |
+| `scanl` | Stay eager; lazy sibling deferred | Genuinely streamable — result element `i` depends only on elements `0..i`. Deferred only because the input is an `A[]`, already fully materialized, so a sibling buys nothing until list functions accept `Iterable`. |
+| `scanl1` | Stay eager; deferred with `scanl` | Thin wrapper over `scanl`; follows whatever `scanl` does. |
+| `scanr` | **Stay eager — permanently** | Right-to-left: the first result needs the *last* input element, so no output can be produced before the entire input is consumed. A generator would be a lie — all the work happens before the first yield. |
+| `scanr1` | **Stay eager — permanently** | Wrapper over `scanr`; additionally calls `last(xs)`/`init(xs)`, which are whole-list operations. |
+| `zip` | Stay eager; lazy sibling deferred | Streamable in principle (yield pairs as both inputs advance), but the current implementation calls `toShortest`, which measures both lists up front — it is array-shaped by construction. Value only appears once inputs may be `Iterable` (the classic `zip(naturals, xs)` case). |
+| `zip3`, `zip4`, `zipN` | Stay eager; deferred with `zip` | All delegate to `zipN`/`toShortest`; same reasoning, same blocker. |
+| `zipWith`, `zipWith3`, `zipWithN` | Stay eager; deferred with `zip` | Same shape as `zip`, with an op applied per pair. |
+| `unzip` | **Stay eager — permanently** | Returns a *tuple of lists* (`[T1[], T2[]]`), not a list. There is nothing to yield: emitting the second output list lazily would require buffering the whole input anyway. Not a generator-shaped function. |
+| `unzipN` | **Stay eager — permanently** | Same as `unzip`, generalized to `T[][]`. Also folds over the entire input to fill every output list in one pass. |
+
+## Why the scan family stays eager
+
+The distinction is direction, not effort. `scanl` walks left-to-right and could
+emit each accumulated value as it goes, so it is a legitimate future generator.
+`scanr` walks right-to-left and its *first* output depends on the *last* input;
+converting it would produce a generator that does 100% of its work before the
+first `next()` returns — worse than eager (same cost, more indirection, plus a
+misleading laziness contract).
+
+The deferral of `scanl`/`scanl1` is about inputs, not outputs. Both take `A[]`.
+When the caller already holds the whole array, a lazy scan saves only the
+`fn` applications past the caller's break point — a real but small win, and not
+worth two more public exports right now. It becomes clearly worth it the moment
+`scanl` accepts an `Iterable`, at which point `scanlIter` should land in the
+same change as that signature widening.
+
+## Why the zip/unzip family stays eager
+
+`zip*` splits cleanly from `unzip*`:
+
+- `zip*` is *deferred*. Zipping is the canonical lazy operation in Haskell
+  precisely because it lets you zip an infinite list against a finite one. In
+  `fjl` today it cannot: every entry point routes through `toShortest`, which
+  needs both lengths, and both parameters are typed `T[]`. Converting the output
+  alone would not deliver the property that makes lazy `zip` interesting.
+- `unzip*` is *permanently* eager. It is not a list producer — it produces a
+  fixed-size tuple of lists. There is no meaningful yield sequence, and
+  producing the second output stream lazily would require retaining the entire
+  input regardless. It is the one family in this audit that should never get a
+  generator sibling.
+
+## What would unblock the deferred conversions
+
+Everything marked "deferred" above is blocked on the same prerequisite: **list
+functions accepting `Iterable<T>` inputs rather than `T[]`**. `take` and
+`takeWhile` already do (#87); `scanl` and `zip*` do not. That widening is its
+own piece of work — it touches `toShortest`, `reduce`, and `length` in
+`list/utils/` — and should be tracked separately. Until then, adding `scanlIter`
+or `zipIter` would ship the lazy half of a pipeline whose eager half still
+forces the whole input.
+
+## Incidental findings — not fixed here
+
+Found while auditing; recorded so they are not lost. All four are pre-existing
+and out of scope for #121, which is a laziness ticket, not a semantics ticket.
+
+| Finding | Detail |
+| --- | --- |
+| `scanr`'s doc-comment is wrong | It claims `head(scanr(fn, z, xs)) === foldr(fn, z, xs)`. Verified: `scanr((a, b) => a + b, 0, [1, 2, 3])` returns `[3, 5, 6]` while `foldr` returns `6` — it is **`last`**, not `head`, that matches. The implementation pushes right-to-left, so the output is reversed relative to the Haskell original. |
+| `scanl` omits the seed | Haskell's `scanl (+) 0 [1,2,3]` is `[0,1,3,6]`; `fjl`'s returns `[1,3,6]`. The doc-comment reproduces the Haskell form (`[z, z \`f\` x1, ...]`), which the implementation does not satisfy. `last(scanl f z xs) === foldl f z xs` *does* hold. |
+| `scanl1` drops the head | Haskell's `scanl1 (+) [1,2,3]` is `[1,3,6]`; `fjl`'s returns `[3,6]`, because it forwards `xs[0]` as the seed and the seed is not emitted. Its doc-comment asserts the Haskell form. |
+| `scanr1` drops the last | `scanr1((a, b) => a + b, [1,2,3])` returns `[5,6]`, symmetric to the `scanl1` case. |
+
+The four are one decision, not four: either `scan*` emits the seed (Haskell
+semantics, breaking) or the doc-comments are corrected to describe what the code
+does (non-breaking). It belongs with #122's per-module implementation review.

--- a/packages/fjl/src/list/replicate.ts
+++ b/packages/fjl/src/list/replicate.ts
@@ -2,6 +2,8 @@ export const
 
   /**
    * Returns a list containing `x` repeated `n` number of times.
+   *
+   * @note Eager;  For the lazy variant @see `replicateIter`.
    */
   replicate = <T>(n: number, x: T): T[] => Array(n).fill(x, 0, n),
 
@@ -10,3 +12,36 @@ export const
    */
   $replicate = <T>(n: number) => (x: T): T[] => replicate(n, x)
 ;
+
+/**
+ * Generator that yields each successive prefix of `replicate(n, x)` - the bounded
+ * form of `repeat`;  Yields `n` times, then completes (`replicateIter(n, x)` is to
+ * `repeat(x)` what `take(n, xs)` is to `xs`).
+ *
+ * ```javascript
+ * const gen = replicateIter(3, 'a');
+ * console.log(gen.next().value);  // ['a']
+ * console.log(gen.next().value);  // ['a', 'a']
+ * console.log(gen.next().value);  // ['a', 'a', 'a']
+ * console.log(gen.next().done);   // true
+ * ```
+ *
+ * @note The last value yielded is (deep) equal to `replicate(n, x)`.
+ * @note As with `iterate`, and `repeat`, the yielded list is the same, growing,
+ *  list reference on every iteration - `slice` it when a snapshot is required.
+ * @note `n` of `Infinity` gives `repeat(x)`;  `n` of `0` (or less) yields nothing.
+ */
+export function* replicateIter<T>(n: number, x: T): Generator<T[], void> {
+  const out = [] as T[];
+
+  for (let i = 0; i < n; i += 1) {
+    out.push(x);
+    yield out;
+  }
+}
+
+/**
+ * Curried version of `replicateIter`.
+ */
+export const $replicateIter = <T>(n: number) =>
+  (x: T): Generator<T[], void> => replicateIter(n, x);

--- a/packages/fjl/src/list/unfoldr.ts
+++ b/packages/fjl/src/list/unfoldr.ts
@@ -1,30 +1,77 @@
 /**
  * Unfoldr operation - Takes a `b` to produce an `a` (`A`) from.
  *
- * @todo Letters should be flipped in initial type;  E.g.,
- *  UnfoldrOp<B, A>;
+ * @note Generics are ordered by role - element type (`A`) first, seed type (`B`)
+ *  second - not by parameter position;  This matches `unfoldr<A, B>`'s own order,
+ *  the op's *return* tuple (`[A, B]`), and the sibling `ScanlOp<A, B>`/
+ *  `ScanrOp<A, B>` types (whose first generic is likewise not their first
+ *  parameter).  They are therefore intentionally not flipped.
  */
 export type UnfoldrOp<A, B> = (b: B | undefined, i?: number, as?: A[]) => [A, B] | undefined;
 
 /**
- * Unfoldr takes an operation, and a starting value (`b`),
- * and produces a list made up of the collected `a`s returned in
- * the operation's return value `[a, b]`.  @note `b` in the return
- * value is passed back into the unfoldr operation func. until the `b`
- * returned is `undefined`.
+ * Generator that yields each successive prefix of the list `unfoldr` builds;
+ * i.e., the lazy sibling of `unfoldr` - it lets callers stop early, and so lets
+ * `op`s that never return `undefined` be consumed safely.
  *
- * The operation is the 'dual' of `foldr`; `foldr` reduces a list to a
- * summary value; `unfoldr` produces a list from a starting value.
+ * ```javascript
+ * const countdown = (x) => x - 1 >= 0 ? [x, x - 1] : undefined;
+ *
+ * const gen = unfoldrIter(countdown, 10);
+ * console.log(gen.next().value);  // [10]
+ * console.log(gen.next().value);  // [10, 9]
+ * // ...
+ *
+ * // Stop early on an operation that never terminates
+ * for (const xs of unfoldrIter(x => [x, x + 1], 0)) {
+ *   if (xs.length === 3) break;  // [0, 1, 2]
+ * }
+ * ```
+ *
+ * @note The last value yielded is (deep) equal to `unfoldr(op, b)`.
+ * @note As with `iterate`, and `repeat`, the yielded list is the same, growing,
+ *  list reference on every iteration - `slice` it when a snapshot is required;
+ *  it is also the list handed to `op` as its third argument.
  */
-export const unfoldr = <A, B>(op: UnfoldrOp<A, B>, b: B): A[] => {
-    const out = [] as A[];
+export function* unfoldrIter<A, B>(op: UnfoldrOp<A, B>, b: B): Generator<A[], void> {
+  const out = [] as A[];
 
-    let ind = 0,
-      resultTuple = op(b, ind, out);
+  let ind = 0,
+    resultTuple = op(b, ind, out);
 
-    while (resultTuple) {
-      out.push(resultTuple[0]);
-      resultTuple = op(resultTuple[1], ++ind, out);
+  while (resultTuple) {
+    out.push(resultTuple[0]);
+    yield out;
+    resultTuple = op(resultTuple[1], ++ind, out);
+  }
+}
+
+/**
+ * Curried version of `unfoldrIter`.
+ */
+export const $unfoldrIter = <A, B>(op: UnfoldrOp<A, B>) =>
+  (b: B): Generator<A[], void> => unfoldrIter(op, b);
+
+export const
+
+  /**
+   * Unfoldr takes an operation, and a starting value (`b`),
+   * and produces a list made up of the collected `a`s returned in
+   * the operation's return value `[a, b]`.  @note `b` in the return
+   * value is passed back into the unfoldr operation func. until the `b`
+   * returned is `undefined`.
+   *
+   * The operation is the 'dual' of `foldr`; `foldr` reduces a list to a
+   * summary value; `unfoldr` produces a list from a starting value.
+   *
+   * @note Eager - `op` must eventually return `undefined`, else the call never
+   *  returns;  For the lazy variant @see `unfoldrIter`.
+   */
+  unfoldr = <A, B>(op: UnfoldrOp<A, B>, b: B): A[] => {
+    let out = [] as A[];
+
+    for (const xs of unfoldrIter(op, b)) {
+      out = xs;
     }
 
     return out;

--- a/packages/fjl/tests/list/test-replicate.ts
+++ b/packages/fjl/tests/list/test-replicate.ts
@@ -1,4 +1,4 @@
-import {replicate} from "../../src/list";
+import {$replicate, $replicateIter, replicate, replicateIter} from "../../src/list";
 
 const {stringify} = JSON;
 
@@ -13,4 +13,62 @@ describe('#replicate', () => {
         expect(replicate(...args)).toEqual(expected);
       });
     });
+
+  it('should be curried via `$replicate`', () => {
+    expect($replicate<number>(3)(9)).toEqual([9, 9, 9]);
+  });
+});
+
+describe('#replicateIter', () => {
+  type UnwrappedYield = number;
+
+  (<[Parameters<typeof replicateIter<UnwrappedYield>>, UnwrappedYield[]][]>[
+    [[0, 1], []],
+    [[2, 3], [3, 3]],
+    [[4, 5], [5, 5, 5, 5]],
+  ])
+    .forEach(([args, expected]) => {
+      it(`replicateIter(${stringify(args)}) yields every prefix of ${stringify(expected)}`, () => {
+        let count = 0;
+        for (const result of replicateIter(...args)) {
+          expect(result.slice(0)).toEqual(expected.slice(0, ++count));
+        }
+        expect(count).toEqual(expected.length);
+      });
+    });
+
+  it('should yield a last value equal to `replicate`\'s return value', () => {
+    let last = [] as number[];
+    for (const result of replicateIter(4, 5)) {
+      last = result.slice(0);
+    }
+    expect(last).toEqual(replicate(4, 5));
+  });
+
+  it('should be lazy - it should not materialize anything the caller does not pull', () => {
+    // `Infinity` proves laziness here;  the eager `replicate` cannot express this
+    // (`Array(Infinity)` throws), and a non-lazy implementation would never return.
+    const gen = replicateIter(Infinity, 'x');
+
+    expect(gen.next().value).toEqual(['x']);
+    expect(gen.next().value).toEqual(['x', 'x']);
+    expect(gen.next().value).toEqual(['x', 'x', 'x']);
+    expect(gen.next().done).toEqual(false);
+  });
+
+  it('should allow the caller to stop early', () => {
+    const takeCount = 3,
+      out = [] as string[][];
+
+    for (const result of replicateIter(Infinity, 'x')) {
+      out.push(result.slice(0));
+      if (out.length === takeCount) break;
+    }
+
+    expect(out).toEqual([['x'], ['x', 'x'], ['x', 'x', 'x']]);
+  });
+
+  it('should be curried via `$replicateIter`', () => {
+    expect([...$replicateIter<number>(2)(9)].pop()).toEqual([9, 9]);
+  });
 });

--- a/packages/fjl/tests/list/test-unfoldr.ts
+++ b/packages/fjl/tests/list/test-unfoldr.ts
@@ -1,12 +1,95 @@
-import {unfoldr} from "../../src/list/unfoldr";
+import {$unfoldr, $unfoldrIter, unfoldr, unfoldrIter, UnfoldrOp} from "../../src/list/unfoldr";
+
+const countdownFrom: UnfoldrOp<number, number> = minuend => {
+    const diff = minuend - 1;
+    return diff >= 0 ? [minuend, diff] : undefined;
+  },
+
+  // Operation that never returns `undefined` - unusable with the eager `unfoldr`
+  countUpFrom: UnfoldrOp<number, number> = x => [x, x + 1];
 
 describe('#unfoldr', () => {
   it('should be able to unfold any value from right to left.', () => {
-    expect(
-      unfoldr(minuend => {
-        const diff = minuend - 1;
-        return diff >= 0 ? [minuend, diff] : undefined;
-      }, 10)
-    ).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    expect(unfoldr(countdownFrom, 10)).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  });
+
+  it('should return an empty list when the operation returns `undefined` immediately', () => {
+    expect(unfoldr(() => undefined, 10)).toEqual([]);
+  });
+
+  it('should pass the list accumulated so far to the operation', () => {
+    const seen = [] as number[][];
+
+    unfoldr((x: number, _i, as: number[]) => {
+      seen.push(as.slice(0));
+      return x < 3 ? [x, x + 1] : undefined;
+    }, 0);
+
+    expect(seen).toEqual([[], [0], [0, 1], [0, 1, 2]]);
+  });
+
+  it('should be curried via `$unfoldr`', () => {
+    expect($unfoldr(countdownFrom)(3)).toEqual([3, 2, 1]);
+  });
+});
+
+describe('#unfoldrIter', () => {
+  it('should yield every prefix of the list `unfoldr` builds', () => {
+    const out = [] as number[][];
+
+    for (const xs of unfoldrIter(countdownFrom, 10)) {
+      out.push(xs.slice(0));
+      if (out.length === 3) break;
+    }
+
+    expect(out).toEqual([[10], [10, 9], [10, 9, 8]]);
+  });
+
+  it('should yield a last value equal to `unfoldr`\'s return value', () => {
+    let last = [] as number[];
+    for (const xs of unfoldrIter(countdownFrom, 10)) {
+      last = xs.slice(0);
+    }
+    expect(last).toEqual(unfoldr(countdownFrom, 10));
+  });
+
+  it('should yield nothing when the operation returns `undefined` immediately', () => {
+    expect([...unfoldrIter(() => undefined, 10)]).toEqual([]);
+  });
+
+  it('should be lazy - it should not call the operation until pulled from', () => {
+    let calls = 0;
+
+    const gen = unfoldrIter((x: number) => {
+      calls += 1;
+      return [x, x + 1] as [number, number];
+    }, 0);
+
+    // Nothing runs on construction
+    expect(calls).toEqual(0);
+
+    gen.next();
+    expect(calls).toEqual(1);
+
+    gen.next();
+    expect(calls).toEqual(2);
+  });
+
+  it('should allow the caller to stop early on a non-terminating operation', () => {
+    // The motivating case:  the eager `unfoldr` would loop forever here.
+    const out = [] as number[];
+
+    for (const xs of unfoldrIter(countUpFrom, 0)) {
+      if (xs.length === 3) {
+        out.push(...xs);
+        break;
+      }
+    }
+
+    expect(out).toEqual([0, 1, 2]);
+  });
+
+  it('should be curried via `$unfoldrIter`', () => {
+    expect([...$unfoldrIter(countdownFrom)(3)].pop()).toEqual([3, 2, 1]);
   });
 });


### PR DESCRIPTION
## Summary

Finishes the `iterator` → generator tail for `list/`. `replicate` and `unfoldr`
were the two remaining eager producers; both now have lazy `*Iter` siblings, and
the `scan*`/`zip*`/`unzip*` families have been audited with the verdicts recorded
in [`md/issues/GENERATOR_AUDIT.md`](md/issues/GENERATOR_AUDIT.md).

**No existing signature or return type changed.** Per #121's own rule — *"where a
generator would break existing consumers, keep the eager version and add a
`*`-suffixed generator sibling rather than changing the return type"* — both
conversions took the sibling route.

Closes #121
Contributes to #116

Work-unit id: `121-generators`

## Naming

`*` isn't a legal identifier character, so "`*`-suffixed" is realized as the
repo's existing convention: `range.ts` already ships eager `range` next to the
generator `rangeIter`, the only eager/lazy sibling pair in the codebase. New
pairs follow it — `replicateIter`, `unfoldrIter`, `$replicateIter`,
`$unfoldrIter`.

`rangeIter` carries an `@todo Rename to 'range'`, so the eventual v2 intent is
generator-primary naming. That rename should move `range`, `replicate`, and
`unfoldr` together as one deliberate breaking change, not one function at a time.

### Yield shape

`cycle`/`iterate`/`repeat` don't yield elements — they yield the *list built so
far*, growing by one per iteration (`Generator<T[], void>`). The new siblings
follow that exactly, which gives a law that both test files assert:

> The last value a `*Iter` generator yields is deep-equal to what its eager
> counterpart returns.

As in `iterate`/`repeat`, the yielded array is the same growing reference each
time; callers wanting a snapshot must `slice` it. Documented on both functions.

## Conversion decisions

### `replicate` → keep eager, add `replicateIter`

`replicate` is **bounded by construction**. `n` is finite, so there is nothing to
stop early from and no non-termination to avoid — the motivation that justifies
laziness elsewhere simply doesn't apply. Converting the return type outright
would break every consumer that indexes or `.length`s the result, in exchange for
nothing.

The sibling is still worth shipping: `replicate` is the bounded form of `repeat`,
and `replicateIter(Infinity, x)` degenerates to `repeat(x)` — something eager
`replicate` cannot express at all, since `Array(Infinity)` throws. It also
composes with the generator-friendly `take`/`takeWhile` from #87.

Eager `replicate` keeps its `Array(n).fill(...)` fast path; a generator is not a
faster way to fill a fixed-size array.

### `unfoldr` → keep eager, add `unfoldrIter`

Laziness is a **real fix** here, not a nicety: an `op` that never returns
`undefined` makes eager `unfoldr` loop forever, and `unfoldrIter` makes that same
`op` consumable.

But `unfoldr` has a live in-repo array consumer — `src/list/unzipN.ts` uses its
result as a `T[][]` seed for `foldl` — plus `tests/object/index_test.ts`. Changing
the return type is a breaking change with an in-tree casualty, so: sibling.

Eager `unfoldr` is now implemented **in terms of** `unfoldrIter` (it drains the
generator and returns the last yield), so the two cannot drift apart. Behaviour is
identical, including the accumulated-list third argument handed to `op`, which now
has its own regression test.

## `UnfoldrOp` `@todo` (#116)

```
@todo Letters should be flipped in initial type;  E.g., UnfoldrOp<B, A>;
```

**Resolved as "do not flip"**, and replaced with an `@note` recording why:

1. `UnfoldrOp<A, B>` matches `unfoldr<A, B>`'s own generic order. Flipping the
   type but not the function creates a mismatch; flipping both is a public API
   break for zero benefit.
2. It matches the op's **return** tuple, `[A, B]`.
3. The premise — "generics should follow parameter order" — isn't the convention
   in this module. `ScanlOp<A, B> = (b: B, a: A, ...) => B` has exactly the same
   shape: its first generic is not its first parameter. Flipping `UnfoldrOp`
   alone would make it the odd one out.

Generics here are ordered **by role** (element type first, seed/accumulator
second), not by parameter position. The `@todo` is gone either way, as required.

## Scan/zip audit — documentation only, no scan/zip code touched

| Function | Verdict | Rationale |
| --- | --- | --- |
| `scanl` | Stay eager; lazy sibling **deferred** | Genuinely streamable (result `i` depends only on inputs `0..i`), but input is an already-materialized `A[]`, so a sibling buys nothing until list fns accept `Iterable`. |
| `scanl1` | Stay eager; deferred with `scanl` | Thin wrapper over `scanl`. |
| `scanr` | **Stay eager — permanently** | Right-to-left: the first result needs the *last* input, so no output exists before the whole input is consumed. A generator would do 100% of its work before the first `next()` — a misleading laziness contract. |
| `scanr1` | **Stay eager — permanently** | Wraps `scanr`; also calls `last`/`init`, both whole-list ops. |
| `zip` | Stay eager; **deferred** | Streamable in principle, but every path goes through `toShortest`, which measures both lists up front, and both params are typed `T[]`. |
| `zip3`, `zip4`, `zipN` | Stay eager; deferred with `zip` | All delegate to `zipN`/`toShortest`. |
| `zipWith`, `zipWith3`, `zipWithN` | Stay eager; deferred with `zip` | Same shape as `zip`, op applied per pair. |
| `unzip` | **Stay eager — permanently** | Returns a *tuple of lists*, not a list. Nothing to yield; emitting the second output lazily would buffer the whole input anyway. |
| `unzipN` | **Stay eager — permanently** | Same as `unzip`, generalized; folds over the entire input in one pass. |

Everything marked "deferred" is blocked on the same prerequisite: **list functions
accepting `Iterable<T>` instead of `T[]`**. `take`/`takeWhile` already do (#87);
`scanl` and `zip*` do not. Shipping `scanlIter`/`zipIter` today would deliver the
lazy half of a pipeline whose eager half still forces the whole input. That
widening touches `toShortest`/`reduce`/`length` and deserves its own issue.

### Incidental findings — recorded, not fixed

Found while auditing; all pre-existing and out of scope for a laziness ticket.
Verified by running the functions:

| Finding | Detail |
| --- | --- |
| `scanr`'s doc-comment is wrong | Claims `head(scanr(fn, z, xs)) === foldr(fn, z, xs)`. Actual: `scanr(add, 0, [1,2,3])` → `[3,5,6]`, `foldr` → `6`. It's **`last`**, not `head` — the impl pushes right-to-left, so output is reversed vs. Haskell. |
| `scanl` omits the seed | Haskell `scanl (+) 0 [1,2,3]` = `[0,1,3,6]`; fjl returns `[1,3,6]`. Doc-comment reproduces the Haskell form. (`last(scanl f z xs) === foldl f z xs` *does* hold.) |
| `scanl1` drops the head | Haskell = `[1,3,6]`; fjl returns `[3,6]`. |
| `scanr1` drops the last | fjl returns `[5,6]`, symmetric to `scanl1`. |

These four are one decision, not four: either `scan*` emits the seed (Haskell
semantics, breaking) or the doc-comments are corrected to describe the code
(non-breaking). Belongs with #122's per-module implementation review.

## Testing

- `pnpm test` → **133 suites, 1083 tests, all passing** (baseline on `main`:
  133 / 1066 — +17 tests, no suite added since both test files already existed).
- `pnpm build` → exits 0.
- `npx eslint` on all four changed source/test files → clean, no new errors or
  warnings. (Repo-wide `pnpm lint` still fails on pre-existing issues, unchanged.)
- No hooks bypassed — `pre-commit`, `commit-msg`, and `pre-push` all ran clean.

Beyond value correctness, the new tests assert the **laziness property that
motivated the change**, not just outputs:

- `replicateIter(Infinity, 'x')` yields prefixes and stays `done: false` — a
  non-lazy implementation would never return, and eager `replicate` throws here.
- `unfoldrIter` calls `op` exactly once per `next()`, and **zero times before the
  first `next()`** (asserted with a call counter).
- `unfoldrIter` with a never-terminating `op` (`x => [x, x + 1]`) is consumed and
  broken out of — the exact case that hangs eager `unfoldr`.
- Both siblings' last yield is asserted equal to their eager counterpart's return.
- The accumulated-list third argument passed to `unfoldr`'s `op` is now covered.

## Breaking changes

**None, by design.** Every existing export keeps its signature and return type:
`replicate`, `$replicate`, `unfoldr`, `$unfoldr`, and `UnfoldrOp` are unchanged as
public API. Four new exports are added (`replicateIter`, `$replicateIter`,
`unfoldrIter`, `$unfoldrIter`), picked up automatically by `list/index.ts`'s
existing `export *`. `unfoldr`'s internals were rewritten to delegate to the
generator, with behaviour held identical and covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
