### PR TITLE
ci(packages): add npm version lifecycle hooks to releasable packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Mono repo for libraries in the functional-jslib org.
 
 - Test commands are defined on repo root.
 
+### Releasing
+
+- See [md/RELEASING.md](./md/RELEASING.md) for how package versions are bumped,
+  tagged, and published.
+

--- a/md/RELEASING.md
+++ b/md/RELEASING.md
@@ -1,0 +1,143 @@
+# Releasing
+
+How versions get bumped, tagged, and published in this monorepo.
+
+## TL;DR
+
+```shell
+cd packages/fjl                       # or fjl-validator, fjl-inputfilter
+pnpm version prerelease --preid alpha # or patch | minor | major
+git push --follow-tags
+```
+
+Then create a GitHub Release for the new tag - that, and only that, publishes to
+npm.
+
+## The `version` lifecycle
+
+Each releasable package declares npm's three version lifecycle hooks. `pnpm`
+8.13.1 (the pinned `packageManager`) does not implement `version` itself - it
+shells out to `npm version` - so the hooks behave exactly as npm documents them:
+
+| Hook          | Runs                                              | When                                          |
+| ------------- | ------------------------------------------------- | --------------------------------------------- |
+| `preversion`  | clean-tree check, then that package's test suite  | before `version` in `package.json` is touched |
+| `version`     | `pnpm -w run build`                               | after the bump, before the commit is created  |
+| `postversion` | the release commit and annotated tag              | after `package.json` has been written         |
+
+For `packages/fjl`:
+
+```json
+{
+  "scripts": {
+    "preversion": "node ../../node_scripts/tasks/version.mjs precheck && pnpm -w run test:fjl",
+    "version": "pnpm -w run build",
+    "postversion": "node ../../node_scripts/tasks/version.mjs commit-and-tag"
+  }
+}
+```
+
+`fjl-validator` and `fjl-inputfilter` are identical apart from their
+`preversion` test target (`test:fjl-validator`, `test:fjl-inputfilter`).
+
+### Why not the hooks from npm's docs verbatim
+
+npm's canonical example is `"preversion": "npm test"`, `"version": "npm run
+build && git add -A dist"`, `"postversion": "git push && git push --tags && rm
+-rf build/temp"`. None of those three lines survives contact with this repo:
+
+- **There is no per-package `npm test` or `npm run build`.** Jest is configured
+  once at the repo root (`jest.config.mjs`) as a multi-project runner, and
+  rollup likewise (`rollup.config.mjs`), building every package in one pass. The
+  hooks therefore call back into the root with `pnpm -w run <script>` instead of
+  pretending each package owns a toolchain.
+- **`git add -A dist` would stage nothing.** `**/dist` is in `.gitignore`; build
+  output is never committed and is rebuilt by CI on every publish. The `version`
+  hook still runs the build, but purely as a *gate* - the bump aborts if the
+  package no longer compiles.
+- **`rm -rf build/temp` has no analogue.** There is no `build/temp`, and
+  `rollup.config.mjs` already cleans each `packages/*/dist/` before writing.
+
+### Why `postversion` does the committing and tagging
+
+This is the non-obvious part. `npm version` only performs its git work when a
+`.git` entry sits *directly* in the directory it was invoked from -
+`@npmcli/git`'s `is()` stats `cwd + '/.git'` and never walks up the tree. In
+this monorepo the only `.git` lives at the repo root, so running `pnpm version`
+inside `packages/<name>`:
+
+- bumps `package.json` ✅
+- runs all three lifecycle hooks ✅
+- silently skips its "working tree is clean" guard ❌
+- silently skips the release commit and the tag ❌
+
+(Running it from the root instead does not help: `npm version --workspace <pkg>`
+hard-codes `git-tag-version: false` in `lib/commands/version.js`.)
+
+`node_scripts/tasks/version.mjs` restores the two missing steps:
+
+- `precheck` - refuses to bump when `git status --porcelain` is non-empty, which
+  is what npm's own `enforceClean` would have done. `--force` overrides.
+- `commit-and-tag` - creates `chore(release): <name>@<version>` and an annotated
+  tag of the same name, refusing to clobber an existing tag.
+
+Tags are **package-qualified** (`fjl@2.0.0-alpha.6`), not npm's default bare
+`v<version>`, because sibling packages collide otherwise - `fjl-inputfilter` and
+`fjl-validator-recaptcha` are both sitting at `1.3.0` today. Note that npm still
+prints its own `v<version>` line when the command finishes; that string is
+cosmetic, the tag that was actually created is the one `commit-and-tag` reports.
+
+Pushing is deliberately **not** automated. Publishing needs a manual GitHub
+Release regardless (see below), the repo's `pre-push` hook runs the full
+`pnpm test && pnpm build`, and coordinated multi-package bumps are better pushed
+once at the end. `commit-and-tag` prints the exact `git push --follow-tags` to
+run.
+
+## Publishing
+
+Bumping a version does not publish. `.github/workflows/publish.yml` is triggered
+by `release: [created]` - a GitHub Release. Pushing a tag on its own does not
+create a Release, so the version flow above is safe to run at any time.
+
+To publish `fjl`:
+
+1. Bump and push as in the TL;DR.
+2. Create a GitHub Release pointing at the new tag.
+3. `publish.yml` installs, builds, and runs `npm publish` from `packages/fjl`.
+
+`fjl-validator` and `fjl-inputfilter` are not covered by that workflow yet - it
+only publishes `packages/fjl`. Until it is extended, publish them by hand once
+the version commit is pushed:
+
+```shell
+pnpm -w run build
+cd packages/fjl-validator && npm publish
+```
+
+## Packages without version scripts
+
+| Package                   | Why                                                                                                                                                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fjl-validator-recaptcha` | Its rollup target and its jest project are both commented out (`rollup.config.mjs`, `jest.config.mjs`), so there is currently neither a build nor a runnable suite to gate a release on.                     |
+| `fjl-filter`              | Absent from the root `package.json` `workspaces` array and from both the rollup and jest configs, and its `main`/`module` point at a `fjl-input.js` bundle that nothing produces. Dormant.                   |
+| `fjl-labs`                | Listed in `pnpm-workspace.yaml` but has no `package.json` at all - sources only, so there is nothing to version or publish.                                                                                  |
+
+To revive any of them: re-enable it in `rollup.config.mjs` and `jest.config.mjs`,
+add the matching root-level `test:<name>` script, and only then add the three
+hooks.
+
+## Notes
+
+- Run `pnpm version` from *inside* the package directory. At the root it would
+  bump `fjl-monorepo`, which is `private: true` and pinned at `0.0.0` on purpose.
+- `--no-git-tag-version` does **not** skip the commit and tag here, since the
+  hooks - not npm - are what create them. For a bare bump with no gates, no
+  commit, and no tag, go around pnpm (which rejects the flag) and call npm
+  directly: `npm version <bump> --ignore-scripts --no-git-tag-version`.
+- `fjl` is on a prerelease line (`2.0.0-alpha.N`); advance it with
+  `pnpm version prerelease --preid alpha`.
+- Tags predating the monorepo layout are bare (`2.0.0-alpha.5`, `1.12.13`, ...)
+  and all belong to `fjl`. New tags are package-qualified.
+- Cross-package `peerDependencies` ranges (e.g. `fjl-inputfilter` requiring
+  `fjl-validator: ^0.8.0`) are **not** updated automatically - check them by hand
+  when bumping a minor or major.

--- a/node_scripts/tasks/version.mjs
+++ b/node_scripts/tasks/version.mjs
@@ -1,0 +1,96 @@
+/**
+ * Helpers for the `preversion`/`postversion` lifecycle hooks declared by each releasable package.
+ *
+ * `npm version` (which `pnpm version` delegates to, as of pnpm 8.13.1) only performs its git work
+ * when a `.git` entry sits directly in the directory it is invoked from - see `@npmcli/git`'s `is()`,
+ * which stats `cwd + '/.git'` and never walks upwards.  In this monorepo the only `.git` lives at the
+ * repo root, so running `pnpm version <bump>` inside `packages/<name>` bumps `package.json` and runs
+ * the three lifecycle scripts, but silently skips its "working tree is clean" guard, the release
+ * commit, and the tag.  These two subcommands put those steps back.
+ *
+ * Usage (from within a package directory):
+ *
+ *   node ../../node_scripts/tasks/version.mjs precheck [--force]
+ *   node ../../node_scripts/tasks/version.mjs commit-and-tag
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+const {log, error} = console,
+
+  git = (...args) => execFileSync('git', args, {encoding: 'utf8'}).trim(),
+
+  readPkg = () => JSON.parse(fs.readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf8')),
+
+  /**
+   * Tag/commit name for a release, e.g. `fjl@2.0.0-alpha.6`.
+   *
+   * Package-qualified rather than npm's default bare `v<version>` because sibling packages here
+   * collide otherwise (`fjl-inputfilter` and `fjl-validator-recaptcha` both sit at `1.3.0`).
+   */
+  releaseId = pkg => `${pkg.name}@${pkg.version}`,
+
+  /**
+   * Stand-in for npm's own `enforceClean` step, which is skipped in package sub-directories.
+   */
+  precheck = force => {
+    const dirty = git('status', '--porcelain');
+
+    if (!dirty) return;
+
+    if (force) {
+      log(`Working tree is not clean; continuing anyway (--force):\n${dirty}\n`);
+      return;
+    }
+
+    throw new Error(
+      'Git working tree is not clean - commit or stash before bumping a version ' +
+      `(pass --force to override):\n${dirty}`
+    );
+  },
+
+  /**
+   * Creates the release commit and annotated tag that `npm version` would normally have created.
+   */
+  commitAndTag = () => {
+    const pkg = readPkg(),
+      id = releaseId(pkg);
+
+    if (git('tag', '--list', id)) {
+      throw new Error(`Tag "${id}" already exists - refusing to overwrite it.`);
+    }
+
+    git('add', '--', 'package.json');
+    git('commit', '-m', `chore(release): ${id}`);
+    git('tag', '-a', id, '-m', id);
+
+    log(
+      `\nCreated release commit and tag "${id}".\n\n` +
+      'Next steps:\n' +
+      '  1. git push --follow-tags\n' +
+      `  2. Create a GitHub Release for tag "${id}" - that is what triggers ` +
+      '.github/workflows/publish.yml.\n'
+    );
+  }
+;
+
+const [, , subcommand, ...rest] = process.argv;
+
+try {
+  switch (subcommand) {
+    case 'precheck':
+      precheck(rest.includes('--force'));
+      break;
+    case 'commit-and-tag':
+      commitAndTag();
+      break;
+    default:
+      throw new Error(
+        `Unknown subcommand "${subcommand ?? ''}" - expected "precheck" or "commit-and-tag".`
+      );
+  }
+} catch (err) {
+  error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+}

--- a/packages/fjl-inputfilter/package.json
+++ b/packages/fjl-inputfilter/package.json
@@ -9,6 +9,11 @@
     "fjl": "^2.0.0-alpha",
     "fjl-validator": "^0.8.0"
   },
+  "scripts": {
+    "preversion": "node ../../node_scripts/tasks/version.mjs precheck && pnpm -w run test:fjl-inputfilter",
+    "version": "pnpm -w run build",
+    "postversion": "node ../../node_scripts/tasks/version.mjs commit-and-tag"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/functional-jslib/fjl.git"

--- a/packages/fjl-validator/package.json
+++ b/packages/fjl-validator/package.json
@@ -8,6 +8,11 @@
   "peerDependencies": {
     "fjl": "^2.0.0-alpha"
   },
+  "scripts": {
+    "preversion": "node ../../node_scripts/tasks/version.mjs precheck && pnpm -w run test:fjl-validator",
+    "version": "pnpm -w run build",
+    "postversion": "node ../../node_scripts/tasks/version.mjs commit-and-tag"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/functional-jslib/fjl.git"

--- a/packages/fjl/package.json
+++ b/packages/fjl/package.json
@@ -11,6 +11,11 @@
     "./package.json",
     "./LICENSE"
   ],
+  "scripts": {
+    "preversion": "node ../../node_scripts/tasks/version.mjs precheck && pnpm -w run test:fjl",
+    "version": "pnpm -w run build",
+    "postversion": "node ../../node_scripts/tasks/version.mjs commit-and-tag"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/functional-jslib/fjl.git"


### PR DESCRIPTION
## Summary

Adds npm's `preversion` / `version` / `postversion` lifecycle hooks to the three
releasable packages so that a version bump is gated by tests and a build, and
produces a proper release commit + tag.

Closes #101

Work unit: `101-npm-version-scripts`

## Changes

- `packages/fjl/package.json`, `packages/fjl-validator/package.json`,
  `packages/fjl-inputfilter/package.json` — added the three lifecycle hooks.
- `node_scripts/tasks/version.mjs` (new) — `precheck` and `commit-and-tag`
  subcommands used by the hooks.
- `md/RELEASING.md` (new) — the release/versioning flow, and the reasoning
  behind every deviation from the issue's example snippet.
- `README.md` — a two-line pointer to the new doc.

Root `package.json` was **not** touched; the hooks reuse the `test:*` and
`build` scripts that already exist there.

The hooks, e.g. for `fjl`:

```json
{
  "preversion": "node ../../node_scripts/tasks/version.mjs precheck && pnpm -w run test:fjl",
  "version": "pnpm -w run build",
  "postversion": "node ../../node_scripts/tasks/version.mjs commit-and-tag"
}
```

## Which packages, and which were skipped

| Package | Hooks | Why |
| --- | --- | --- |
| `fjl` | yes | Published by `.github/workflows/publish.yml`; built by rollup; tested by jest. |
| `fjl-validator` | yes | In root `workspaces`, built, tested, published on npm. |
| `fjl-inputfilter` | yes | In root `workspaces`, built, tested, published on npm. |
| `fjl-validator-recaptcha` | no | Its rollup target and its jest project are both commented out, so there is currently neither a build nor a runnable suite to gate a release on (`jest --selectProjects fjl-validator-recaptcha` exits 1 with "no projects were found"). |
| `fjl-filter` | no | Not in root `workspaces`, not in `rollup.config.mjs` or `jest.config.mjs`, and its `main`/`module` point at a `fjl-input.js` bundle nothing produces. Dormant. |
| `fjl-labs` | no | Listed in `pnpm-workspace.yaml` but has no `package.json` at all — sources only. |

## Deviations from the issue's example snippet

The issue's snippet is `"preversion": "npm test"`, `"version": "npm run build &&
git add -A dist"`, `"postversion": "git push && git push --tags && rm -rf
build/temp"`. Every line needed adapting:

1. **`npm test` / `npm run build` do not exist per package.** Jest is configured
   once at the root (`jest.config.mjs`, a multi-project runner selected with
   `--selectProjects`) and rollup likewise (`rollup.config.mjs`, builds all
   packages in one pass). The hooks therefore call back into the root with
   `pnpm -w run <script>`.
2. **`git add -A dist` would stage nothing.** `**/dist` is in `.gitignore`;
   build output is never committed and CI rebuilds it on publish. The `version`
   hook still runs the build, but as a *gate* — the bump aborts if the package
   stopped compiling.
3. **`rm -rf build/temp` has no analogue.** No such directory;
   `rollup.config.mjs` already cleans each `packages/*/dist/` before writing.
4. **`postversion` commits and tags instead of pushing.** This is the
   non-obvious one. `npm version` (which pnpm 8.13.1 delegates to — it does not
   implement `version` itself) only performs git work when a `.git` entry sits
   *directly* in its cwd: `@npmcli/git`'s `is()` is
   `stat(cwd + '/.git')` and never walks up. The only `.git` here is at the repo
   root, so `pnpm version` inside `packages/<name>` bumps `package.json` and
   runs all three hooks but **silently skips its clean-tree guard, the release
   commit, and the tag**. Running it from the root does not help either:
   `npm version --workspace <pkg>` hard-codes `'git-tag-version': false` in
   `lib/commands/version.js`. `node_scripts/tasks/version.mjs` puts the two
   missing steps back.
5. **Tags are package-qualified** (`fjl@2.0.0-alpha.6`) rather than npm's bare
   `v<version>`, because siblings collide otherwise — `fjl-inputfilter` and
   `fjl-validator-recaptcha` are both at `1.3.0` today.
6. **Pushing is not automated.** `publish.yml` triggers on `release: [created]`,
   so a tag push alone publishes nothing and a manual GitHub Release is required
   regardless; the repo's `pre-push` hook runs the full `pnpm test && pnpm
   build`, making a push-per-package expensive; and coordinated multi-package
   bumps are better pushed once. `commit-and-tag` prints the exact
   `git push --follow-tags` to run next.

## How this was validated without cutting a release

**No version was bumped, no tag was created, and nothing was published in this
repo.** `git diff origin/main` touches only `scripts` blocks; the three package
versions are still `2.0.0-alpha.5`, `0.8.0`, `1.3.0`, and the tag count is
unchanged at 139.

1. **Every referenced command was run directly.** From each package directory,
   `pnpm run preversion` and `pnpm run version` were executed on their own — all
   exit 0 (`fjl` 125 suites / 920 tests, `fjl-validator` 6 / 33,
   `fjl-inputfilter` 2 / 113; `pnpm -w run build` exits 0 from a package dir).
2. **`precheck` was exercised in this repo** (it is read-only): it correctly
   failed while the working tree was dirty and passed once the tree was clean.
3. **The full lifecycle was run end-to-end in a throwaway scratch repo** that
   mirrors this layout (root `pnpm-workspace.yaml` + `packages/fjl`,
   `packageManager` pinned to `pnpm@8.13.1`), using a byte-for-byte copy of
   `version.mjs` and the real `scripts` block from `packages/fjl/package.json`,
   with the root `test:fjl`/`build` stubbed to `echo`. Result: hooks ran in
   order, and the commit `chore(release): fjl@2.0.0-alpha.6` plus annotated tag
   `fjl@2.0.0-alpha.6` were created, touching only `packages/fjl/package.json`.
   Guard rails were verified too — re-running `commit-and-tag` refuses an
   existing tag, and an unknown subcommand exits 1.
4. **The generated commit message was checked against the repo's commitlint
   config**: `echo "chore(release): fjl@2.0.0-alpha.6" | npx commitlint` exits 0.
5. **The npm behaviour claims were verified against source**, not guessed — read
   from the installed `libnpmversion/lib/version.js`,
   `@npmcli/git/lib/is.js`, and `npm/lib/commands/version.js`.
6. `eslint` and `tsc-files --noEmit` pass on the new `version.mjs`.

## Hooks

No hook was bypassed. `commit-msg`, `pre-commit` (lint-staged), and `pre-push`
(`pnpm test && pnpm build`) all ran and passed normally. The pre-existing
`pnpm lint` failures on `main` and the pre-existing rollup `.d.ts` warnings for
`packages/fjl/dist/esm/object/setTheory.d.ts` are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
