### PR TITLE
test(fjl): #124 assert `$`-prefixed methods are actually curried

### DIFF
--- a/packages/fjl/src/_platform/object/index.ts
+++ b/packages/fjl/src/_platform/object/index.ts
@@ -13,16 +13,18 @@ export const
    * Contains all the static functions from `Object` but curried and flipped;
    * Methods that only take one parameter, or only 'rest' args, are exported as is.
    *
+   * @note These live on `native` - they are not top-level `fjl` exports.
+   *
    * ```typescript
    * // E.g., `Object.defineProperties(obj, descriptor)` can now be used flipped,
    * // and/or, curried:
-   * import {defineProperties, $defineProperties} from 'fjl'
+   * import {native} from 'fjl'
    *
    * // Flipped
-   * defineProperties(descriptor, someObj),
+   * native.defineProperties(descriptor, someObj),
    *
    * // Flipped and Curried
-   * $defineProperties(descriptor)(someObj);
+   * native.$defineProperties(descriptor)(someObj);
    *
    * // etc.
    * ```

--- a/packages/fjl/src/function/trampoline.ts
+++ b/packages/fjl/src/function/trampoline.ts
@@ -39,5 +39,13 @@ export const trampoline = <T, RetT>(fn: Nary<T, RetT>, fnName?: string): Nary<T,
     };
   },
 
+  /**
+   * @note Despite its `$` prefix (the library's "curried sibling" convention),
+   *  `$trampoline` is **not** idiomatically curried - it takes the same
+   *  argument tuple as `trampoline` (`(fn, fnName?)`), and is therefore an
+   *  alias for it.  `fnName` is optional, so `$trampoline(fn)` "reads" curried,
+   *  but `$trampoline(fn)` does *not* return a function awaiting `fnName`.
+   *  See `tests/test-currying.ts`.
+   */
   $trampoline =  <T, RetT>(fn: Nary<T, RetT>, fnName?: string): Nary<T, RetT> =>
     trampoline(fn, fnName)

--- a/packages/fjl/src/object/assignDeep.ts
+++ b/packages/fjl/src/object/assignDeep.ts
@@ -41,6 +41,13 @@ export const
 
   /**
    * Curried version of `assignDeep`.
+   *
+   * @todo **Known bug** - the rest-args are forwarded as a single array
+   *  (`assignDeep(obj0, objs)` instead of `assignDeep(obj0, ...objs)`), so
+   *  `$assignDeep(a)(b, c)` merges the *array* `[b, c]` into `a` (producing
+   *  `{0: b, 1: c, ...a}`) rather than `b` and `c` themselves.  `$objUnion`
+   *  aliases this method and inherits the bug.  Pinned by `it.failing` cases
+   *  in `tests/test-currying.ts` (see issue #124) - remove those when fixed.
    */
   $assignDeep = (obj0: any) => (...objs: any[]) => assignDeep(obj0, objs)
 

--- a/packages/fjl/tests/curry-helpers.ts
+++ b/packages/fjl/tests/curry-helpers.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared helpers for asserting that the library's `$`-prefixed methods are
+ * actually curried.
+ *
+ * `fjl` uses "idiomatic" currying (see #40) - a curried method applies one
+ * argument group per call (`f(a)(b)(c)`), it does *not* accept an arbitrary
+ * argument tuple per call (`f(a, b)(c)`), which is what the (deprecated)
+ * `curry*` family in `src/function/curry.ts` does.  The assertions below are
+ * written against the idiomatic form.
+ *
+ * @see https://github.com/functional-jslib/fjl/issues/124
+ */
+
+export type AnyFn = (...args: any[]) => any;
+
+/**
+ * Produces a *fresh* argument list for one invocation - a factory (instead of
+ * a literal list) so methods that mutate their arguments (`push`, `pushN`,
+ * `defineProp`, etc.) get clean arguments for every call we make.
+ */
+export type ArgsFactory = () => any[];
+
+export interface CurryCase {
+  /** Arguments, in the un-curried sibling's argument order. */
+  args: ArgsFactory;
+
+  /**
+   * Number of arguments consumed by each application, e.g., `[1, 2]` means
+   * `f(a)(b, c)`.  Must sum to `args().length`.  Defaults to one argument per
+   * application (`[1, 1, ...]`).
+   */
+  groups?: number[];
+
+  /**
+   * Maps a raw return value (and the arguments it was produced from) into
+   * something comparable via `expect(...).toEqual(...)`;  Required for methods
+   * returning functions/generators, or communicating via side effects.
+   */
+  finalize?: (result: any, args: any[]) => any;
+
+  /** Optional label, used in the generated test name. */
+  label?: string;
+}
+
+export interface CurrySpec {
+  /** Un-curried sibling's export name, when it isn't the `$`-name sans `$`. */
+  sibling?: string;
+
+  /**
+   * Explicit un-curried counterpart;  Overrides the `sibling` lookup - for the
+   * few methods whose un-curried equivalent requires some assembly.
+   */
+  uncurried?: AnyFn;
+
+  /** At least one case is required. */
+  cases: CurryCase[];
+
+  /**
+   * Set to `false` where the method mutates its *first* argument group - a
+   * re-used partial can't be expected to be pure, in that case.
+   */
+  reusablePartial?: boolean;
+
+  /**
+   * Set (with a reason) where the method is known to *fail* the assertions;
+   * Generated cases are then registered via `it.failing`, which fails the
+   * suite if/when the method starts passing (so the note can't go stale).
+   */
+  knownFailure?: string;
+
+  /**
+   * Set (with a reason) where the `$`-prefixed method is verifiably *not*
+   * curried;  Only the "agrees with un-curried sibling" assertion is then
+   * meaningful, and an extra test pins the (documented) non-curried arity.
+   */
+  notCurried?: string;
+}
+
+export type CurryRegistry = Record<string, CurrySpec>;
+
+export const
+
+  /** One argument per application. */
+  defaultGroups = (len: number): number[] => new Array(len).fill(1),
+
+  sum = (xs: number[]): number => xs.reduce((a, b) => a + b, 0),
+
+  /**
+   * Applies `args` to `f`, `groups` at a time, and returns the final result;
+   * `groups` is expected to align with the head of `args`.
+   */
+  applyInGroups = (f: AnyFn, args: any[], groups: number[]): any => {
+    let offset = 0,
+      received: any = f;
+    groups.forEach(size => {
+      received = (received as AnyFn)(...args.slice(offset, offset + size));
+      offset += size;
+    });
+    return received;
+  },
+
+  /** Renders `f(_)(_, _)` style test names. */
+  curriedCallSignature = (name: string, groups: number[]): string =>
+    `${name}${groups.map(size =>
+      `(${new Array(size).fill('_').join(', ')})`).join('')}`,
+
+  /**
+   * Asserts that `curried` is an idiomatically curried counterpart of
+   * `uncurried`, for one argument case:
+   *
+   * 1. Every application before the last one returns a function.
+   * 2. Fully applied, `curried` agrees with `uncurried`.
+   * 3. A partially applied `curried` is re-usable - currying yields a new
+   *    function per application, so the partial must not be consumed by, or
+   *    carry state over from, a prior completion.
+   */
+  assertCurriedCase = (
+    curried: AnyFn,
+    uncurried: AnyFn,
+    _case: CurryCase,
+    reusablePartial = true
+  ): void => {
+    const finalize = _case.finalize ?? ((x: any) => x),
+      expectedArgs = _case.args(),
+      groups = _case.groups ?? defaultGroups(expectedArgs.length);
+
+    // Guard against mis-specified fixtures
+    expect(sum(groups)).toEqual(expectedArgs.length);
+    expect(typeof curried).toEqual('function');
+    expect(typeof uncurried).toEqual('function');
+
+    const expected = finalize(uncurried(...expectedArgs), expectedArgs);
+
+    // 1. + 2.
+    const args = _case.args();
+    let offset = 0,
+      received: any = curried;
+
+    groups.forEach((size, ind) => {
+      // Not fully applied yet - must (still) be a function
+      expect(typeof received).toEqual('function');
+      received = (received as AnyFn)(...args.slice(offset, offset + size));
+      offset += size;
+      if (ind < groups.length - 1) {
+        // Called with fewer than all argument groups - must return a function
+        expect(typeof received).toEqual('function');
+      }
+    });
+
+    expect(finalize(received, args)).toEqual(expected);
+
+    // 3.
+    if (!reusablePartial || groups.length < 2) return;
+
+    const headArgs = _case.args(),
+      head = headArgs.slice(0, groups[0]),
+      tailGroups = groups.slice(1),
+      partial = curried(...head) as AnyFn;
+
+    expect(typeof partial).toEqual('function');
+
+    [0, 1].forEach(() => {
+      const tail = _case.args().slice(groups[0]),
+        result = applyInGroups(partial, tail, tailGroups);
+      expect(finalize(result, head.concat(tail))).toEqual(expected);
+    });
+  }
+
+;

--- a/packages/fjl/tests/test-currying.ts
+++ b/packages/fjl/tests/test-currying.ts
@@ -1,0 +1,476 @@
+/**
+ * Asserts that every `$`-prefixed export (the library's "curried sibling"
+ * convention) is *actually* curried.
+ *
+ * The list of methods under test is derived from the package's public export
+ * surface at runtime - `curriedRegistry` only supplies the argument fixtures.
+ * Two "meta" tests keep the two in sync, so a curried method added later fails
+ * this suite until it gets coverage here.
+ *
+ * @see https://github.com/functional-jslib/fjl/issues/124
+ */
+import * as fjl from '../src';
+import {defaultErrorMessageCall} from '../src/errorThrowing';
+import {
+  AnyFn,
+  CurryRegistry,
+  assertCurriedCase,
+  curriedCallSignature,
+  defaultGroups
+} from './curry-helpers';
+
+const
+
+  // Fixture helpers
+  // ---------------
+  /** Static (never mutated) argument list. */
+  fixed = (...xs: any[]) => () => xs,
+
+  add = (a: number, b: number): number => a + b,
+  isEven = (x: number): boolean => x % 2 === 0,
+  lt3 = (x: number): boolean => x < 3,
+  eq = (a: any, b: any): boolean => a === b,
+  asc = (a: any, b: any): number => a > b ? 1 : (a < b ? -1 : 0),
+  incr = (x: number): number => x + 1,
+  tuple2 = (a: any, b: any): [any, any] => [a, b],
+  tuple3 = (a: any, b: any, c: any): [any, any, any] => [a, b, c],
+
+  nums = [1, 2, 3, 4, 5],
+  alphabet = 'abcdefghijklmnopqrstuvwxyz',
+
+  /** Collects the first `n` (copied) yields of a generator. */
+  takeFromGen = (n: number) => (gen: Generator<any>): any[] => {
+    const out: any[] = [];
+    for (const x of gen) {
+      out.push(Array.isArray(x) ? x.slice(0) : x);
+      if (out.length >= n) break;
+    }
+    return out;
+  },
+
+  /** `forEach`-style fixture - the operation records what it was called with. */
+  recorderArgs = (xs: any[]) => (): any[] => {
+    const calls: any[] = [],
+      op: any = (x: any) => calls.push(x);
+    op.calls = calls;
+    return [op, xs];
+  },
+
+  recorded = (_result: any, args: any[]): any => args[0].calls,
+
+  /** Applies the returned function - for methods that return functions. */
+  callWith = (...args: any[]) => (f: AnyFn): any => f(...args),
+
+  factorialProcess = (n: number, agg = 1): any =>
+    n > 1 ? () => factorialProcess(n - 1, agg * n) : agg,
+
+  // Registry
+  // --------
+  curriedRegistry: CurryRegistry = {
+
+    // boolean
+    $equal: {cases: [{args: fixed(99, 99)}, {args: fixed(1, 2)}]},
+
+    // function
+    $apply: {cases: [{args: fixed(add, [1, 2])}]},
+
+    $bind: {
+      cases: [{
+        args: fixed(tuple3, 1, 2),
+        groups: [1, 2],
+        finalize: callWith(3)
+      }]
+    },
+
+    $fnOrError: {cases: [{args: fixed('someName', add)}]},
+
+    $trampoline: {
+      notCurried: '`$trampoline` takes the same argument tuple as `trampoline` ' +
+        '(`(fn, fnName?)`), so it is an alias, not an idiomatically curried sibling',
+      cases: [{args: fixed(factorialProcess), finalize: callWith(5)}]
+    },
+
+    $until: {cases: [{args: fixed((x: number) => x >= 5, incr, 0)}]},
+
+    // errorThrowing
+    $errorIfNotType: {
+      cases: [{
+        args: fixed(Number, 'someContext', 'someValue', 99, 'suffix'),
+        groups: [1, 1, 1, 2]
+      }]
+    },
+
+    $errorIfNotTypes: {
+      cases: [{
+        args: fixed([Number, String], 'someContext', 'someValue', 'abc', 'suffix'),
+        groups: [1, 1, 1, 2]
+      }]
+    },
+
+    $getErrorIfNotTypeThrower: {
+      // The un-curried counterpart returns an un-curried thrower, hence the
+      // "assembly" here - `$`-version returns the curried thrower.
+      uncurried: (cb, Type, ctx, name, value) =>
+        fjl.getErrorIfNotTypeThrower(cb)(Type, ctx, name, value),
+      cases: [{
+        args: fixed(defaultErrorMessageCall, Number, 'someContext', 'someValue', 99)
+      }]
+    },
+
+    $getErrorIfNotTypesThrower: {
+      uncurried: (cb, Types, ctx, name, value) =>
+        fjl.getErrorIfNotTypesThrower(cb)(Types, ctx, name, value),
+      cases: [{
+        args: fixed(defaultErrorMessageCall, [Number, String], 'someContext', 'someValue', 99)
+      }]
+    },
+
+    // number
+    $normalizeStep: {
+      sibling: 'normalizeStepOrThrow',
+      cases: [{args: fixed(1, 10, 2)}, {args: fixed(10, 1, 2)}]
+    },
+
+    // string / _platform.string
+    $split: {cases: [{args: fixed(',', 'a,b,c')}]},
+
+    // _platform.object
+    $hasOwnProperty: {cases: [{args: fixed({a: 1}, 'a')}, {args: fixed({a: 1}, 'b')}]},
+    $instanceOf: {cases: [{args: fixed([], Array)}, {args: fixed('', String)}]},
+
+    // _platform.slice
+    $at: {cases: [{args: fixed(1, nums)}, {args: fixed(-1, nums)}]},
+    $includes: {cases: [{args: fixed(nums, 3)}]},
+    $indexOf: {cases: [{args: fixed(nums, 3)}]},
+    $lastIndexOf: {cases: [{args: fixed([1, 2, 1], 1)}]},
+    $slice: {cases: [{args: fixed(1, 3, nums)}]},
+
+    // object
+    $assignDeep: {
+      knownFailure: '`$assignDeep` forwards its rest-args as a single array ' +
+        '(`assignDeep(obj0, objs)` instead of `assignDeep(obj0, ...objs)`), so ' +
+        'the curried form merges an *array* into `obj0` - see PR for #124',
+      reusablePartial: false,
+      cases: [{
+        args: () => [{a: 1}, {b: 2}, {c: 3}],
+        groups: [1, 2]
+      }]
+    },
+
+    $defineEnumProp: {
+      cases: [{
+        args: () => [Number, {}, 'someProp', 99],
+        groups: [1, 1, 2],
+        finalize: ([target, descriptor]: [any, PropertyDescriptor]) =>
+          [target.someProp, descriptor.enumerable, typeof descriptor.get]
+      }]
+    },
+
+    $defineEnumProps: {
+      cases: [{
+        args: () => [[[Number, 'a', 1], [String, 'b', 'x']], {}],
+        finalize: (target: any) => ({...target})
+      }]
+    },
+
+    $defineProp: {
+      cases: [{
+        args: () => [Number, {}, 'someProp', 99],
+        groups: [1, 1, 2],
+        finalize: ([target, descriptor]: [any, PropertyDescriptor]) =>
+          [target.someProp, descriptor.enumerable, typeof descriptor.get]
+      }]
+    },
+
+    $defineProps: {
+      cases: [{
+        args: () => [[[Number, 'a', 1], [String, 'b', 'x']], {}],
+        finalize: (target: any) => [target.a, target.b]
+      }]
+    },
+
+    $lookup: {cases: [{args: fixed('a', {a: 1, b: 2})}]},
+
+    $objComplement: {
+      cases: [{args: fixed({a: 1}, {a: 1, b: 2}, {a: 1, c: 3}), groups: [1, 2]}]
+    },
+
+    $objDifference: {cases: [{args: fixed({a: 1, b: 2}, {a: 1})}]},
+
+    $objIntersect: {cases: [{args: fixed({a: 1, b: 2}, {b: 3})}]},
+
+    $objUnion: {
+      knownFailure: '`$objUnion` is `$assignDeep` - see the `$assignDeep` entry',
+      reusablePartial: false,
+      cases: [{args: () => [{a: 1}, {b: 2}], groups: [1, 1]}]
+    },
+
+    $searchObj: {
+      cases: [
+        {args: fixed('a', {a: {b: 2}})},
+        {args: fixed('a.b', {a: {b: 2}})}
+      ]
+    },
+
+    // list
+    $all: {cases: [{args: fixed(isEven, [2, 4, 6])}, {args: fixed(isEven, nums)}]},
+    $any: {cases: [{args: fixed(isEven, nums)}]},
+    $append: {cases: [{args: fixed([1], [2], [3]), groups: [1, 2]}]},
+    $breakOnList: {cases: [{args: fixed(lt3, nums)}]},
+    $complement: {cases: [{args: fixed([1, 2, 3], [2, 4], [3, 5]), groups: [1, 2]}]},
+    $concatMap: {cases: [{args: fixed((x: number) => [x, x], [[1], [2]])}]},
+    $difference: {cases: [{args: fixed([1, 2, 3], [2])}]},
+    $drop: {cases: [{args: fixed(2, nums)}]},
+    $dropWhile: {cases: [{args: fixed(lt3, nums)}]},
+    $dropWhileEnd: {cases: [{args: fixed((x: number) => x > 3, nums)}]},
+    $elem: {cases: [{args: fixed(nums, 3)}]},
+    $elemIndex: {cases: [{args: fixed(nums, 3)}]},
+    $elemIndices: {cases: [{args: fixed(2, [1, 2, 2, 3])}]},
+    $filter: {cases: [{args: fixed(isEven, nums)}]},
+    $find: {cases: [{args: fixed(isEven, nums)}]},
+    $findIndex: {cases: [{args: fixed(isEven, nums)}]},
+    $findIndexWhere: {cases: [{args: fixed(isEven, nums)}]},
+    $findIndexWhereRight: {cases: [{args: fixed(isEven, nums)}]},
+    $findIndices: {cases: [{args: fixed(isEven, nums)}]},
+    $findIndicesWhere: {cases: [{args: fixed(isEven, nums)}]},
+    $findWhere: {cases: [{args: fixed(isEven, nums)}]},
+    $foldl: {cases: [{args: fixed(add, 0, nums)}]},
+    $foldl1: {cases: [{args: fixed(add, nums)}]},
+    $foldr: {cases: [{args: fixed(add, 0, nums)}]},
+    $foldr1: {cases: [{args: fixed(add, nums)}]},
+
+    $forEach: {
+      reusablePartial: false, // Operation records its calls (is stateful)
+      cases: [{args: recorderArgs(nums), finalize: recorded}]
+    },
+
+    $genericAscOrdering: {cases: [{args: fixed(1, 2)}, {args: fixed(2, 1)}]},
+    $groupBy: {cases: [{args: fixed(eq, [1, 1, 2, 3, 3])}]},
+    $insert: {cases: [{args: fixed(3, [1, 2, 4, 5])}]},
+    $insertBy: {cases: [{args: fixed(asc, 3, [1, 2, 4, 5])}]},
+    $intercalate: {cases: [{args: fixed([0], [[1], [2], [3]])}]},
+    $intersect: {cases: [{args: fixed([1, 2, 3], [2, 3, 4])}]},
+    $intersectBy: {cases: [{args: fixed(eq, [1, 2, 3], [2, 3, 4])}]},
+    $intersperse: {cases: [{args: fixed(0, [1, 2, 3])}]},
+    $isInfixOf: {cases: [{args: fixed('bcd', alphabet)}]},
+    $isPrefixOf: {cases: [{args: fixed('abc', alphabet)}]},
+    $isSubsequenceOf: {cases: [{args: fixed('ace', 'abcde')}]},
+    $isSuffixOf: {cases: [{args: fixed(alphabet, 'xyz')}]},
+
+    $iterate: {cases: [{args: fixed(incr, 5), finalize: takeFromGen(3)}]},
+
+    $map: {cases: [{args: fixed(incr, nums)}]},
+    $mapAccumL: {
+      cases: [{args: fixed((agg: number, x: number) => [agg + x, agg + x], 0, nums)}]
+    },
+    $mapAccumR: {
+      cases: [{args: fixed((agg: number, x: number) => [agg + x, agg + x], 0, nums)}]
+    },
+    $nubBy: {cases: [{args: fixed(eq, [1, 1, 2, 3, 3])}]},
+    $partition: {cases: [{args: fixed(isEven, nums)}]},
+
+    $push: {cases: [{args: () => [6, nums.slice(0)]}]},
+
+    $pushN: {
+      reusablePartial: false, // Mutates its first argument
+      cases: [{args: () => [nums.slice(0), 6, 7], groups: [1, 2]}]
+    },
+
+    $range: {
+      cases: [
+        {args: fixed(0, 5, 1), groups: [1, 2]},
+        {args: fixed(0, 5), groups: [1, 1]}
+      ]
+    },
+
+    $reduce: {cases: [{args: fixed(add, 0, nums)}]},
+    $reduceRight: {cases: [{args: fixed(add, 0, nums)}]},
+    $reduceUntil: {cases: [{args: fixed((x: number) => x > 3, add, 0, nums)}]},
+    $reduceUntilRight: {cases: [{args: fixed((x: number) => x < 3, add, 0, nums)}]},
+    $remove: {cases: [{args: fixed(3, nums)}]},
+    $removeBy: {cases: [{args: fixed(eq, 3, nums)}]},
+    $removeFirstsBy: {cases: [{args: fixed(eq, nums, [2, 4])}]},
+    $replicate: {cases: [{args: fixed(3, 'a')}]},
+    $scanl: {cases: [{args: fixed(add, 0, nums)}]},
+    $scanl1: {cases: [{args: fixed(add, nums)}]},
+    $scanr: {cases: [{args: fixed(add, 0, nums)}]},
+    $scanr1: {cases: [{args: fixed(add, nums)}]},
+    $sliceFrom: {cases: [{args: fixed(2, nums)}]},
+    $sliceTo: {cases: [{args: fixed(2, nums)}]},
+    $sortBy: {cases: [{args: fixed(asc, [3, 1, 2])}]},
+    $sortOn: {cases: [{args: fixed((x: number[]) => x[0], [[2, 'b'], [1, 'a']])}]},
+    $span: {cases: [{args: fixed(lt3, nums)}]},
+    $splitAt: {cases: [{args: fixed(2, nums)}]},
+    $stripPrefix: {cases: [{args: fixed('abc', alphabet)}]},
+    $swap: {cases: [{args: fixed(0, 2, nums)}]},
+    $take: {cases: [{args: fixed(2, nums)}]},
+    $takeWhile: {cases: [{args: fixed(lt3, nums)}]},
+    $toShortest: {cases: [{args: fixed([1, 2, 3], [4, 5], [6, 7, 8]), groups: [1, 2]}]},
+
+    $unfoldr: {
+      cases: [{
+        args: fixed((b: number) => b < 5 ? [b, b + 1] : undefined, 0)
+      }]
+    },
+
+    $union: {cases: [{args: fixed([1, 2], [2, 3])}]},
+    $unionBy: {
+      cases: [{args: fixed((xs: number[], x: number) => !xs.includes(x), [1, 2], [2, 3])}]
+    },
+    $zip: {cases: [{args: fixed([1, 2], ['a', 'b'])}]},
+    $zip3: {cases: [{args: fixed([1, 2], ['a', 'b'], [true, false])}]},
+    $zipN: {cases: [{args: fixed([1, 2], ['a', 'b'], [true, false]), groups: [1, 2]}]},
+    $zipWith: {cases: [{args: fixed(tuple2, [1, 2], ['a', 'b'])}]},
+    $zipWith3: {cases: [{args: fixed(tuple3, [1, 2], ['a', 'b'], [true, false])}]},
+    $zipWithN: {
+      cases: [{args: fixed(tuple2, [1, 2], ['a', 'b']), groups: [1, 2]}]
+    }
+  },
+
+  /**
+   * `Object.*` statics are re-exported, flipped and curried, on `fjl.native`;
+   * They follow the same `$`-prefix convention, so they get the same treatment.
+   */
+  nativeRegistry: CurryRegistry = {
+    $assign: {cases: [{args: () => [{b: 2}, {a: 1}]}]},
+
+    $create: {
+      cases: [{
+        args: fixed({a: {value: 1, enumerable: true}}, {protoProp: 1}),
+        finalize: (o: any) => [o.a, o.protoProp, Object.keys(o)]
+      }]
+    },
+
+    $defineProperties: {
+      cases: [{
+        args: () => [{a: {value: 1, enumerable: true}}, {}],
+        finalize: (o: any) => ({...o})
+      }]
+    },
+
+    $defineProperty: {
+      cases: [{
+        args: () => [{value: 1, enumerable: true}, 'a', {}],
+        finalize: (o: any) => ({...o})
+      }]
+    },
+
+    $getOwnPropertyDescriptor: {cases: [{args: fixed('a', {a: 1})}]},
+
+    $groupBy: {
+      cases: [{
+        args: fixed((x: number) => isEven(x) ? 'even' : 'odd', nums),
+        finalize: (o: any) => ({...o})
+      }]
+    },
+
+    $hasOwn: {cases: [{args: fixed('a', {a: 1})}, {args: fixed('b', {a: 1})}]},
+
+    $is: {cases: [{args: fixed(1, 1)}, {args: fixed(NaN, NaN)}, {args: fixed(1, 2)}]},
+
+    $setPrototypeOf: {
+      cases: [{
+        args: () => [{protoProp: 1}, {}],
+        finalize: (o: any, args: any[]) => Object.getPrototypeOf(o) === args[0]
+      }]
+    }
+  }
+
+;
+
+/**
+ * Generates the `describe`/`it` blocks for one `$`-prefixed method.
+ */
+const describeCurried = (
+  name: string,
+  siblingName: string,
+  curried: AnyFn,
+  uncurried: AnyFn,
+  spec: CurryRegistry[string]
+): void => {
+  describe(`#${name}`, () => {
+    it(`\`${name}\` is exported as a function`, () => {
+      expect(typeof curried).toEqual('function');
+    });
+
+    it(`\`${name}\` has an un-curried sibling (\`${siblingName}\`)`, () => {
+      expect(typeof uncurried).toEqual('function');
+    });
+
+    if (spec.notCurried) {
+      it(`\`${name}\` is NOT curried - ${spec.notCurried}`, () => {
+        expect(curried.length).toBeGreaterThan(1);
+      });
+    }
+
+    spec.cases.forEach((_case, ind) => {
+      const groups = _case.groups ?? defaultGroups(_case.args().length),
+        suffix = spec.cases.length > 1 ? ` [case ${ind}]` : '',
+        title = `${_case.label ?? curriedCallSignature(name, groups)}` +
+          ` is curried, and agrees with \`${siblingName}\`${suffix}`,
+        register = spec.knownFailure ? it.failing : it;
+
+      register(
+        spec.knownFailure ? `${title} (known failure: ${spec.knownFailure})` : title,
+        () => assertCurriedCase(curried, uncurried, _case, spec.reusablePartial !== false)
+      );
+    });
+  });
+};
+
+describe('curried methods (`$`-prefixed exports)', () => {
+  const exported = fjl as unknown as Record<string, any>,
+    dollarNames = Object.keys(exported).filter(k => k.startsWith('$')).sort();
+
+  describe('#registry', () => {
+    it('covers every `$`-prefixed export', () => {
+      expect(dollarNames.filter(name => !curriedRegistry[name])).toEqual([]);
+    });
+
+    it('contains no entries for non-existent exports', () => {
+      expect(Object.keys(curriedRegistry).filter(name => !(name in exported))).toEqual([]);
+    });
+
+    it('found the expected number of curried methods', () => {
+      // Sanity check - update when curried methods are added/removed
+      expect(dollarNames.length).toBeGreaterThanOrEqual(109);
+    });
+  });
+
+  dollarNames.forEach(name => {
+    const spec = curriedRegistry[name];
+    if (!spec) return; // Reported by the `#registry` tests above
+    const siblingName = spec.sibling ?? name.slice(1);
+    describeCurried(
+      name,
+      spec.uncurried ? `<assembled from \`${siblingName}\`>` : siblingName,
+      exported[name],
+      spec.uncurried ?? exported[siblingName],
+      spec
+    );
+  });
+});
+
+describe('curried methods (`fjl.native` `$`-prefixed statics)', () => {
+  const {native} = fjl as unknown as { native: Record<string, any> },
+    dollarNames = Object.keys(native).filter(k => k.startsWith('$')).sort();
+
+  describe('#registry', () => {
+    it('covers every `$`-prefixed `native` static', () => {
+      expect(dollarNames.filter(name => !nativeRegistry[name])).toEqual([]);
+    });
+  });
+
+  dollarNames.forEach(name => {
+    const spec = nativeRegistry[name];
+    if (!spec) return;
+    const siblingName = spec.sibling ?? name.slice(1);
+    describeCurried(
+      name,
+      `native.${siblingName}`,
+      native[name],
+      spec.uncurried ?? native[siblingName],
+      spec
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a shared currying assertion helper and a **data-driven** suite that asserts every `$`-prefixed export in `fjl` is *actually* curried. The target list is derived from the package's public export surface **at runtime** (not hand-written), so curried methods added later are picked up automatically and fail the suite until they get argument fixtures.

Closes #124

Work-unit id: `124-curry-tests`

## How the helper works

`packages/fjl/tests/curry-helpers.ts` exports `assertCurriedCase(curried, uncurried, case, reusablePartial)`. `fjl` uses *idiomatic* currying (`f(a)(b)(c)`) rather than the deprecated `curry*`/argument-tuple form, so the assertions are written against that. Per argument case it asserts:

1. **Partial application returns a function** — every application before the last one yields a function.
2. **Full application agrees with the un-curried sibling** — `$f(a)(b)(c)` deep-equals `f(a, b, c)`.
3. **Partials are re-usable** — a partially applied method completed twice (with fresh tails) yields the same result both times, i.e. currying returns a fresh function rather than a consumed/stateful one.

Fixture shape (`CurryCase` / `CurrySpec`):

- `args` is an **argument *factory***, not a literal list, so methods that mutate their arguments (`push`, `pushN`, `defineProp`, …) get clean args for every one of the ~5 invocations an assertion makes.
- `groups` describes the application split, e.g. `[1, 2]` ⇒ `f(a)(b, c)` — needed for the variadic-tail methods (`$append`, `$complement`, `$zipN`, `$zipWithN`, `$toShortest`, `$pushN`, `$range`, `$objComplement`, `$bind`) and the deeper ones (`$defineProp` ⇒ `[1, 1, 2]`, `$errorIfNotType` ⇒ `[1, 1, 1, 2]`).
- `finalize` maps a result into something comparable — for methods returning functions (`$bind`, `$trampoline`), generators (`$iterate`), or communicating by side effect (`$forEach`).
- `sibling` / `uncurried` handle the methods whose un-curried counterpart isn't simply the `$`-name minus its `$` (`$normalizeStep` → `normalizeStepOrThrow`; `$getErrorIfNotType(s)Thrower`, whose un-curried equivalent needs assembling).
- `knownFailure` registers the case via `it.failing`, so a real bug is pinned rather than papered over — and the suite goes **red** if the method is ever fixed without removing the note.
- `notCurried` documents a `$`-prefixed method that verifiably isn't curried.

`packages/fjl/tests/test-currying.ts` holds the registry and the driver. Two meta-tests keep registry and export surface in sync:

- *"covers every `$`-prefixed export"* — fails listing any uncovered `$` export.
- *"contains no entries for non-existent exports"* — fails on stale fixtures.

## Coverage

**118 of 118 curried methods asserted:**

- **109 / 109** `$`-prefixed top-level exports of `packages/fjl/src` (`list/`, `list/utils/`, `object/`, `string/`, `boolean/`, `number/`, `function/`, `errorThrowing/`, `_platform/`).
- **9 / 9** `$`-prefixed, flipped-and-curried `Object` statics on the `fjl.native` export (`$assign`, `$create`, `$defineProperties`, `$defineProperty`, `$getOwnPropertyDescriptor`, `$groupBy`, `$hasOwn`, `$is`, `$setPrototypeOf`) — same convention, same helper.

(The ~112 `$` identifiers greppable in `src` include `$zip4`/`zip4`, which `list/index.ts` never re-exports, `$concat`, which is shadowed by `list/concat.ts` and reachable only as `$append`, and the `$UnionBy`/`$defineProperties` *type*/doc mentions.)

## Methods that failed the currying assertion

### 1. `$assignDeep` — real behavioural bug (registered `it.failing`, **not** fixed here)

```ts
$assignDeep = (obj0: any) => (...objs: any[]) => assignDeep(obj0, objs)
//                                                              ^^^^ should be `...objs`
```

`assignDeep`'s signature is `(obj0, ...objs)`, so the curried version merges the *array* `objs` into `obj0`:

```
assignDeep({a: 1}, {b: 2}, {c: 3})  // => {a: 1, b: 2, c: 3}     (correct)
$assignDeep({a: 1})({b: 2}, {c: 3}) // => {0: {b: 2}, 1: {c: 3}, a: 1}  (wrong)
```

### 2. `$objUnion` — same bug (alias)

`object/setTheory.ts` defines `$objUnion = $assignDeep`, so it inherits the defect:

```
objUnion({a: 1}, {b: 2})  // => {a: 1, b: 2}
$objUnion({a: 1})({b: 2}) // => {0: {b: 2}, a: 1}
```

**What I did:** per the work-unit brief, no library behaviour was changed (a one-character fix here would collide with concurrent work on `32-type-system-cleanup` / `121-generators`). Both are registered with `it.failing` and a `knownFailure` reason, and `src/object/assignDeep.ts` carries a `@todo` known-bug doc note. **These two need their own ticket**; when fixed, the `it.failing` registrations must be dropped (the suite will go red otherwise, by design).

### 3. `$trampoline` — not curried; documentation corrected

```ts
$trampoline = (fn, fnName?) => trampoline(fn, fnName)
```

It takes the same argument tuple as `trampoline`, i.e. it's an alias, not an idiomatically curried sibling. `$trampoline(fn)` *reads* curried only because `fnName` is optional — it does not return a function awaiting `fnName`. Nothing documented it as curried, so per acceptance criterion 3 the **documentation was corrected**: a doc-block now states it explicitly, and the suite pins the non-curried arity via `notCurried`.

## Other documentation corrections (no behaviour changes)

- `src/_platform/object/index.ts` — the `native` doc-block told users to `import {defineProperties, $defineProperties} from 'fjl'`; those aren't top-level exports, they live on `native`. Example corrected.

## Test layout

Follows the dominant existing convention (`packages/fjl/tests/**`, `test-*.ts`) — no new convention, and no attempt at the co-location migration (#77 / #125).

## Testing evidence

Baseline (`origin/main`):

```
Test Suites: 133 passed, 133 total
Tests:       1066 passed, 1066 total
```

This branch (`pnpm test`):

```
Test Suites: 134 passed, 134 total
Tests:       1437 passed, 1437 total
```

`+1` suite, `+371` tests, all green. `pnpm build` exits `0`. `eslint` and `tsc-files --noEmit` are clean on all five changed/added files (repo-wide `pnpm lint` failures are pre-existing on `main` and untouched). No git hooks were bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
